### PR TITLE
fixed declaration of speech_set_voice block for mozilla compatibility.

### DIFF
--- a/demos/speech/blocks.js
+++ b/demos/speech/blocks.js
@@ -9,8 +9,6 @@ Blockly.Blocks['listen_if'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(0);
-    this.setTooltip('');
-    this.setHelpUrl('http://www.example.com/');
   }
 };
 
@@ -29,8 +27,6 @@ Blockly.Blocks['listen_bool'] = {
         .appendField("you say");
     this.setOutput(true, null);
     this.setColour(0);
-    this.setTooltip('');
-    this.setHelpUrl('http://www.example.com/');
   }
 };
 
@@ -49,8 +45,6 @@ Blockly.Blocks['listen_text'] = {
         .appendField("what you say");
     this.setOutput(true, "String");
     this.setColour(0);
-    this.setTooltip('');
-    this.setHelpUrl('http://www.example.com/');
   }
 };
 
@@ -68,8 +62,6 @@ Blockly.Blocks['display_img'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(60);
-    this.setTooltip('');
-    this.setHelpUrl('http://www.example.com/');
   }
 };
 
@@ -90,8 +82,6 @@ Blockly.Blocks['display_pause'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(60);
-    this.setTooltip('');
-    this.setHelpUrl('http://www.example.com/');
   }
 };
 
@@ -114,8 +104,6 @@ Blockly.Blocks['display_update_text'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(60);
-    this.setTooltip('');
-    this.setHelpUrl('http://www.example.com/');
   }
 };
 
@@ -138,12 +126,10 @@ Blockly.Blocks['display_clear_text'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(60);
-    this.setTooltip('');
-    this.setHelpUrl('http://www.example.com/');
   }
 };
 
-Blockly.JavaScript['display_clear_text'] = function(block) {
+Blockly.JavaScript['display_clear_text'] = function() {
   var code = 'clearText("textArea");\n';
   return code;
 };
@@ -157,8 +143,6 @@ Blockly.Blocks['speech_speak'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(30);
-    this.setTooltip('');
-    this.setHelpUrl('http://www.example.com/');
   }
 };
 
@@ -167,7 +151,7 @@ Blockly.JavaScript['speech_speak'] = function(block) {
   var code;
   if (value_to_say !== '' && value_to_say !== null){
     code = 'globalSay(' + value_to_say + ');\n';
-  } 
+  }
   else{
     code = '\n';
   }
@@ -175,11 +159,13 @@ Blockly.JavaScript['speech_speak'] = function(block) {
 };
 
 /** helper function for the 'speech_set_voice' block;
- * @param {!Array.<SpeechSynthesisVoice>} the available voices
- * @return {!Array.<!Array.<string>>} the dropdown options
+ *
+ * @param {!Array.<SpeechSynthesisVoice>} voices - the available voices
+ * @return {!Array.<!Array.<string>>} dropdown - the dropdown options
  */
 var getVoicesForBlock = function(voices){
   var dropdown = [];
+  var i;
   for (i = 0; i < voices.length; i++){
     var voice = [voices[i].name, i.toString()];
     dropdown.push(voice);
@@ -188,40 +174,30 @@ var getVoicesForBlock = function(voices){
 };
 
 
-/** the voice list is loaded async to the page. An onvoiceschanged event is fired when they are loaded.
- *  http://stackoverflow.com/questions/21513706/getting-the-list-of-voices-in-speechsynthesis-of-chrome-web-speech-api
+/** the voice list is loaded async to the page in Chrome. An onvoiceschanged
+ * event is fired when they are loaded.
+ * http://stackoverflow.com/questions/21513706/getting-the-list-of-voices-in-speechsynthesis-of-chrome-web-speech-api
  */
 var voices = window.speechSynthesis.getVoices();
+var setVoiceBlock = {
+  init: function() {
+    this.appendDummyInput()
+        .appendField("set voice to")
+        .appendField(
+          new Blockly.FieldDropdown(getVoicesForBlock(voices)), "VOICES");
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(30);
+  }
+};
 if (voices.length > 0){
-  Blockly.Blocks['speech_set_voice'] = {
-    init: function() {
-      this.appendDummyInput()
-          .appendField("set voice to")
-          .appendField(new Blockly.FieldDropdown(getVoicesForBlock(voices)), "VOICES");
-      this.setPreviousStatement(true, null);
-      this.setNextStatement(true, null);
-      this.setColour(30);
-      this.setTooltip('');
-      this.setHelpUrl('http://www.example.com/');
-    }
-  };
+  Blockly.Blocks['speech_set_voice'] = setVoiceBlock;
 } else {
-   // wait on voices to be loaded before fetching list
+   // Wait on voices to be loaded before fetching list
   window.speechSynthesis.onvoiceschanged = function(){
-    //voices becomes {!Array.<SpeechSynthesisVoice>}
+    //Voices becomes {!Array.<SpeechSynthesisVoice>}
     voices = window.speechSynthesis.getVoices();
-    Blockly.Blocks['speech_set_voice'] = {
-      init: function() {
-        this.appendDummyInput()
-            .appendField("set voice to")
-            .appendField(new Blockly.FieldDropdown(getVoicesForBlock(voices)), "VOICES");
-        this.setPreviousStatement(true, null);
-        this.setNextStatement(true, null);
-        this.setColour(30);
-        this.setTooltip('');
-        this.setHelpUrl('http://www.example.com/');
-      }
-    };
+    Blockly.Blocks['speech_set_voice'] = setVoiceBlock;
   };
 }
 //set voice based on user's dropdown choice
@@ -237,7 +213,7 @@ Blockly.JavaScript['speech_set_voice'] = function(block) {
   return code;
 };
 
-//set volume of speech
+// Set volume of speech
 Blockly.Blocks['speech_set_volume'] = {
   init: function() {
     this.appendValueInput("VOLUME")
@@ -246,20 +222,20 @@ Blockly.Blocks['speech_set_volume'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(30);
-    this.setTooltip('');
-    this.setHelpUrl('http://www.example.com/');
   }
 };
 
 Blockly.JavaScript['speech_set_volume'] = function(block) {
-  var value_volume = Blockly.JavaScript.valueToCode(block, 'VOLUME', Blockly.JavaScript.ORDER_ATOMIC);
+  var value_volume = Blockly.JavaScript.valueToCode(
+    block, 'VOLUME', Blockly.JavaScript.ORDER_ATOMIC);
   var code = '';
-  if (value_volume >= 0 && value_volume <= 1)
+  if (value_volume >= 0 && value_volume <= 1){
     code = 'setVolume('+ value_volume+');\n';
+  }
   return code;
 };
 
-//set rate of speech
+// Set rate of speech
 Blockly.Blocks['speech_set_rate'] = {
   init: function() {
     this.appendValueInput("RATE")
@@ -268,19 +244,20 @@ Blockly.Blocks['speech_set_rate'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(30);
-    this.setTooltip('');
-    this.setHelpUrl('http://www.example.com/');
   }
 };
 
 Blockly.JavaScript['speech_set_rate'] = function(block) {
-  var value_rate = Blockly.JavaScript.valueToCode(block, 'RATE', Blockly.JavaScript.ORDER_ATOMIC);
+  var value_rate = Blockly.JavaScript.valueToCode(
+    block, 'RATE', Blockly.JavaScript.ORDER_ATOMIC);
   var code = '';
-  if (value_rate >= .1 && value_rate <= 10)
+  if (value_rate >= .1 && value_rate <= 10){
     code = 'setRate('+ value_rate+');\n';
+  }
   return code;
 };
 
+var opt = [["replacing old text", "REPLACE"], ["adding to old text", "APPEND"]];
 Blockly.Blocks['speech_say_and_write'] = {
   init: function() {
     this.appendValueInput("TEXT")
@@ -288,19 +265,19 @@ Blockly.Blocks['speech_say_and_write'] = {
         .appendField("say and write");
     this.appendDummyInput()
         .appendField("by")
-        .appendField(new Blockly.FieldDropdown([["replacing old text", "REPLACE"], ["adding to old text", "APPEND"]]), "WRITE_TYPE");
+        .appendField(new Blockly.FieldDropdown(opt), "WRITE_TYPE");
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(30);
-    this.setTooltip('');
-    this.setHelpUrl('http://www.example.com/');
   }
 };
 
 Blockly.JavaScript['speech_say_and_write'] = function(block) {
-  var value_update_text = Blockly.JavaScript.valueToCode(block, 'TEXT', Blockly.JavaScript.ORDER_ATOMIC);
+  var value_update_text = Blockly.JavaScript.valueToCode(
+    block, 'TEXT', Blockly.JavaScript.ORDER_ATOMIC);
   var dropdown_write_type = block.getFieldValue('WRITE_TYPE');
-    var code = 'if(' + Blockly.JavaScript.quote_(dropdown_write_type) + ' == "REPLACE"){\n\
+  var code = 'if(' + Blockly.JavaScript.quote_(dropdown_write_type) + ' ==\
+     "REPLACE"){\n\
       clearText("textArea");\n\
     }\n\
     appendText("p", '+ value_update_text + ',"textArea");\n\

--- a/demos/speech/blocks.js
+++ b/demos/speech/blocks.js
@@ -15,10 +15,10 @@ Blockly.Blocks['listen_if'] = {
 };
 
 Blockly.JavaScript['listen_if'] = function(block) {
-    var text_word = Blockly.JavaScript.valueToCode(block, 'WORD', Blockly.JavaScript.ORDER_ATOMIC);
-    var statements_do = Blockly.JavaScript.statementToCode(block, 'DO');
-    addRecognizableWord(text_word);
-    return 'if (listen_branch('+formatText(text_word)+')) {\n' + statements_do + '}\n';
+  var text_word = Blockly.JavaScript.valueToCode(block, 'WORD', Blockly.JavaScript.ORDER_ATOMIC);
+  var statements_do = Blockly.JavaScript.statementToCode(block, 'DO');
+  addRecognizableWord(text_word);
+  return 'if (listen_branch('+formatText(text_word)+')) {\n' + statements_do + '}\n';
 };
 
 //listen_bool returns a boolean value, true if the user says a specified word and false otherwise
@@ -35,11 +35,11 @@ Blockly.Blocks['listen_bool'] = {
 };
 
 Blockly.JavaScript['listen_bool'] = function(block) {
-    var text_word = Blockly.JavaScript.valueToCode(block, 'WORD', Blockly.JavaScript.ORDER_ATOMIC);
-    addRecognizableWord(text_word);
-    window.console.log(text_word + " "+ formatText(text_word));
-    var code = 'listen_branch('+formatText(text_word)+')';
-    return [code, Blockly.JavaScript.ORDER_ATOMIC];
+  var text_word = Blockly.JavaScript.valueToCode(block, 'WORD', Blockly.JavaScript.ORDER_ATOMIC);
+  addRecognizableWord(text_word);
+  window.console.log(text_word + " "+ formatText(text_word));
+  var code = 'listen_branch('+formatText(text_word)+')';
+  return [code, Blockly.JavaScript.ORDER_ATOMIC];
 };
 
 //listen_text returns a String containing what the user said
@@ -167,7 +167,7 @@ Blockly.JavaScript['speech_speak'] = function(block) {
   var code;
   if (value_to_say !== '' && value_to_say !== null){
     code = 'globalSay(' + value_to_say + ');\n';
-  }  
+  } 
   else{
     code = '\n';
   }
@@ -176,24 +176,38 @@ Blockly.JavaScript['speech_speak'] = function(block) {
 
 /** helper function for the 'speech_set_voice' block;
  * @param {!Array.<SpeechSynthesisVoice>} the available voices
- * @return {!Array.<!Array.<string>>} the dropdown options 
+ * @return {!Array.<!Array.<string>>} the dropdown options
  */
 var getVoicesForBlock = function(voices){
   var dropdown = [];
   for (i = 0; i < voices.length; i++){
     var voice = [voices[i].name, i.toString()];
     dropdown.push(voice);
-  };
+  }
   return dropdown;
-}
+};
 
 
 /** the voice list is loaded async to the page. An onvoiceschanged event is fired when they are loaded.
  *  http://stackoverflow.com/questions/21513706/getting-the-list-of-voices-in-speechsynthesis-of-chrome-web-speech-api
  */
-var voices; 
- // wait on voices to be loaded before fetching list
-window.speechSynthesis.onvoiceschanged = function(){
+var voices = window.speechSynthesis.getVoices();
+if (voices.length > 0){
+  Blockly.Blocks['speech_set_voice'] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField("set voice to")
+          .appendField(new Blockly.FieldDropdown(getVoicesForBlock(voices)), "VOICES");
+      this.setPreviousStatement(true, null);
+      this.setNextStatement(true, null);
+      this.setColour(30);
+      this.setTooltip('');
+      this.setHelpUrl('http://www.example.com/');
+    }
+  };
+} else {
+   // wait on voices to be loaded before fetching list
+  window.speechSynthesis.onvoiceschanged = function(){
     //voices becomes {!Array.<SpeechSynthesisVoice>}
     voices = window.speechSynthesis.getVoices();
     Blockly.Blocks['speech_set_voice'] = {
@@ -208,8 +222,8 @@ window.speechSynthesis.onvoiceschanged = function(){
         this.setHelpUrl('http://www.example.com/');
       }
     };
-};
-
+  };
+}
 //set voice based on user's dropdown choice
 //default is Alex
 Blockly.JavaScript['speech_set_voice'] = function(block) {

--- a/demos/speech/blocks.js
+++ b/demos/speech/blocks.js
@@ -201,15 +201,12 @@ if (voices.length > 0){
   };
 }
 //set voice based on user's dropdown choice
-//default is Alex
+
 Blockly.JavaScript['speech_set_voice'] = function(block) {
   var dropdown_name = block.getFieldValue('VOICES');
   // var newVoice = voices[parseInt(dropdown_name)];
   var voiceIndex = parseInt(dropdown_name);
-  var code = 'voices = getVoices();\n\
-    var voiceIndex = ' + voiceIndex + ';\n\
-    var newVoice = voices[voiceIndex];\n\
-    setVoice(voiceIndex);';
+  var code = 'setVoice(' + voiceIndex + ');\n';
   return code;
 };
 

--- a/demos/speech/index.html
+++ b/demos/speech/index.html
@@ -91,7 +91,7 @@
       <p>Make your own adventure through speech synthesis, speech reognition, text, and pictures. Create your own or check out some of our demos shown below.</p>
       <p id = "logText"><code>Logging messages will be displayed here.</code></p>
       <p>
-        <button onclick="showCode()">Show JavaScript</button>   
+        <button onclick="showCode()">Show JavaScript</button>
         <button onclick="runCode()">Start Adventure</button>
         <button onclick="clearWorkspace()">Clear</button>
 
@@ -112,10 +112,10 @@
   </aside>
 
 
-  <section id="blocklyDiv" style= "height: 480px; width: 900px;"></div>    
+  <section id="blocklyDiv" style= "height: 480px; width: 900px;"></div>
 
   <xml id="toolbox" style="display: none">
-    
+
     <category name="Listen" colour="0">
       <block type="listen_if">
          <value name="WORD">
@@ -557,12 +557,12 @@
   </section>
 
   <script>
-  var workspace = Blockly.inject('blocklyDiv',  
+  var workspace = Blockly.inject('blocklyDiv',
         {media: '../../media/',
          toolbox: document.getElementById('toolbox')});
-  
+
   //Button listeners
-  
+
   /**
    * Loads demo into Blockly workspace.
    * @param {String} xmlID Loads into workspace blocks defined in xmlID.
@@ -602,7 +602,7 @@
   var clearWorkspace = function() {
     workspace.clear();
   };
-   
+
   </script>
 
 

--- a/demos/speech/speech.js
+++ b/demos/speech/speech.js
@@ -2,12 +2,13 @@
 
 var recognizableWords = []; //keeps track of all the words that the recognizer should listen for
 
-/*var workspace = Blockly.inject('blocklyDiv',  
+var workspace = Blockly.inject('blocklyDiv',
     {media: '../../media/',
-     toolbox: document.getElementById('toolbox')});*/
+     toolbox: document.getElementById('toolbox')});
 
-if (!('webkitSpeechRecognition' in window)) {
-  alert("Speech recognition and speech synthesis not supported. Please use Chrome to run this demo.");
+if (!('webkitSpeechRecognition' in window) && !('SpeechRecognition' in window)) {
+  alert("Speech recognition and speech synthesis not supported. Please use \
+    Chrome to run this demo.");
 }
 
 //allows for portability across different browsers
@@ -189,7 +190,7 @@ var runCode = function() {
       };
       return myInterpreter.createPrimitive(textArea);
     };
-    //denotes to the interpreter that upon calls to clearText, it should execute the wrapper function defined. 
+    //denotes to the interpreter that upon calls to clearText, it should execute the wrapper function defined.
     myInterpreter.setProperty(scope, 'clearText', myInterpreter.createNativeFunction(clearTextWrapper));
 
     /** appendText to the given div within JSInterpreter

--- a/demos/speech/speech.js
+++ b/demos/speech/speech.js
@@ -1,12 +1,14 @@
+/**
+ * @fileoverview TODO(quacht)
+ */
+
 'use strict';
+//namespace
+var speech = {};
+//keeps track of all the words that the recognizer should listen for
+var recognizableWords = [];
 
-var recognizableWords = []; //keeps track of all the words that the recognizer should listen for
-
-var workspace = Blockly.inject('blocklyDiv',
-    {media: '../../media/',
-     toolbox: document.getElementById('toolbox')});
-
-if (!('webkitSpeechRecognition' in window) && !('SpeechRecognition' in window)) {
+if (!('webkitSpeechRecognition' in window) && !('SpeechRecognition' in window)){
   alert("Speech recognition and speech synthesis not supported. Please use \
     Chrome to run this demo.");
 }
@@ -14,274 +16,21 @@ if (!('webkitSpeechRecognition' in window) && !('SpeechRecognition' in window)) 
 //allows for portability across different browsers
 var SpeechRecognition = SpeechRecognition || webkitSpeechRecognition;
 var SpeechGrammarList = SpeechGrammarList || webkitSpeechGrammarList;
-var SpeechRecognitionEvent = SpeechRecognitionEvent || webkitSpeechRecognitionEvent;
-//global instance whose attributes may be editted in order to affect speech output
+var SpeechRecognitionEvent = SpeechRecognitionEvent ||
+    webkitSpeechRecognitionEvent;
+
+//global instance whose attributes may be edited in order to affect speech
+//output
 var msg = new SpeechSynthesisUtterance();
 
 /**
- * Associated with the "Show Javascript button", outputs the code in an alert window
+ * Associated with the "Show Javascript button", outputs the code in an alert
+ * window
  */
-var showCode = function() {   
+var showCode = function() {
   Blockly.JavaScript.INFINITE_LOOP_TRAP = null;
   var code = Blockly.JavaScript.workspaceToCode(workspace);
   alert(code);
-};
-
-
-/**
- * Generate JavaScript code and run it using the JS Interpreter, prints code to console for debugging. Defines 
- * wrappers (syncronously and asyncronously) to handle certain blocks that cannot be handled by the JS Interpreter
- * internally.
- * NOTE: If move the wrapper functions outside of runCode, then myInterpreter is not in scope (needs to be a 
- * local because it needs to be recreated each time to allow for changes to code), and myInterpreter can't be
- * passed as an argument because the order and type of arguments is defined by JS Interpreter.
- */
-var runCode = function() {
-  var code = Blockly.JavaScript.workspaceToCode(workspace);
-  window.console.log(code);
-
-  //used to define wrappers for myInterpreter
-  var initFunc = function(myInterpreter,scope) {
-
-    /**
-     * Wrapper to define alert. Taken from JS Interpreter documentation on Blockly developer site. 
-     * @param {String} text to be displayed
-     */
-    var alertWrapper = function(text) {
-      text = text ? text.toString() : '';
-      return myInterpreter.createPrimitive(alert(text));
-    };
-    myInterpreter.setProperty(scope, 'alert',
-        myInterpreter.createNativeFunction(alertWrapper));
-
-    //Listen blocks
-
-    /**
-     * Wrapper to return a boolean if what the user says matches word. Uses JS Interpreter to make this an 
-     * asynchronous function so that execution blocks until the user says a word and the word is processed. 
-     * Assumes word has been formatted to be in lower case with no extraneous characters (using formatText).
-     * Used in listen_if and listen_bool.
-     * @param {String} word The word to be compared against
-     * @param {fuction} callback The callback used by JS Interpreter to resume execution
-     * @return {boolean} true if the word the user says equals word, false otherwise
-     */
-    var listenBranchWrapper = function(word,callback) {
-        word = word ? word.toString() : '';
-        var localRecognizer = new SpeechRecognition();
-        updateGrammars(localRecognizer);
-        localRecognizer.start();
-        logMessage(myInterpreter,"Listening...");
-        localRecognizer.onresult = function() {
-          var speechResult = formatText(event.results[0][0].transcript);
-          logMessage(myInterpreter, 'You said: \"' + speechResult + '\"\n');
-          callback(myInterpreter.createPrimitive(speechResult == word));
-        };
-        localRecognizer.onnomatch = function() {
-          logMessage(myInterpreter,"Done listening. Didn't hear anything.");
-          callback(myInterpreter.createPrimitive(false));
-        };
-        localRecognizer.onerror = function() {
-          logMessage(myInterpreter,"Done listening. Error.");
-          callback(myInterpreter.createPrimitive(false));
-      };
-    };
-  myInterpreter.setProperty(scope,'listen_branch', myInterpreter.createAsyncFunction(listenBranchWrapper));
-
-    /**
-     * Wrapper to return the string the user said. Uses JS Interpreter to make this an asynchronous function so
-     * that execution blocks until the user says a word and the word is processed. Used in listen_text.
-     * @param {function} callback Used by JS Interpreter to resume execution after blocking
-     * @return {String} returns the string the user spoke
-     */
-    var listenTextWrapper = function(callback) {
-      var localRecognizer = new SpeechRecognition();
-      updateGrammars(localRecognizer);
-      localRecognizer.start();
-      logMessage(myInterpreter,"Listening...");
-      localRecognizer.onresult = function() {
-          var speechResult = event.results[0][0].transcript;
-          logMessage(myInterpreter, 'You said: \"' + speechResult + '\"');
-          callback(myInterpreter.createPrimitive(speechResult));
-      };
-      localRecognizer.onnomatch = function() {
-          logMessage(myInterpreter,"Done listening. No match found.");
-          callback(myInterpreter.createPrimitive(false));
-      };
-      localRecognizer.onerror = function() {
-          logMessage(myInterpreter,"Done listening. Error.");
-          callback(myInterpreter.createPrimitive(false));
-      };
-    };
-    myInterpreter.setProperty(scope,'listen_text', myInterpreter.createAsyncFunction(listenTextWrapper));
-
-    //Display blocks
-
-    /**
-     * Wrapper to update the displayed image in HTML div element displayPic. Needs to be done in wrapper because
-     * JS Interpreter can't access displayPic internally. Used in display_img.
-     * @param {String} url The URL of the picture to be displayed.
-     */
-    var imageWrapper = function(url) {
-      url = url ? url.toString() : '';
-      return myInterpreter.createPrimitive(window.document.getElementById('displayPic').src = url);
-    };
-    myInterpreter.setProperty(scope, 'displayImage',
-        myInterpreter.createNativeFunction(imageWrapper));
-
-    /**
-     * Wrapper to pause execution for a certain number of milliseconds and then resume execution. Uses JS 
-     * Interpreter to make this an asynchronous function so that execution blocks until the user says a word
-     * and the word is processed. Used in pause.
-     * @param {float} time Number of milliseconds to pause execution
-     * @param {function} callback Used by JS Interpreter to resume execution after blocking.
-     */
-
-    var timeVar; 
-
-    var pauseWrapper = function(time,callback) {
-      time = time ? time.toString() : '';
-      timeVar = parseInt(time);
-      window.console.log(timeVar);  
-      var resume = function() {
-        callback();
-      };
-      return myInterpreter.createPrimitive(window.setTimeout(resume,timeVar));
-    };
-    myInterpreter.setProperty(scope, 'pause',
-        myInterpreter.createAsyncFunction(pauseWrapper));
-
-    //speech
-    var speechWrapper = function(wordsToSay,callback){
-      wordsToSay = wordsToSay ? wordsToSay.toString() : '';
-      if ('speechSynthesis' in window) {
-        localMsg = new SpeechSynthesisUtterance(wordsToSay);
-        window.speechSynthesis.speak(localMsg);
-      // Synthesis support. Make your web apps talk!
-      } else {
-        logMessage(myInterpreter,"speechSynthesis not found. Text to speech capability under Web Speech API not supported.")
-      }
-      localMsg.onend = function(e) {
-        callback();
-      };
-    };
-    myInterpreter.setProperty(scope, 'say', myInterpreter.createAsyncFunction(speechWrapper));
-
-    //display text
-    var textWrapper = function(text) {
-      text = text ? text.toString() : '';
-      return myInterpreter.createPrimitive(document.getElementById('displayText').textContent = text);
-    };
-    myInterpreter.setProperty(scope, 'updateTextDisplay',
-        myInterpreter.createNativeFunction(textWrapper));
-
-
-    /** clear the textArea div
-     * @param {String} id attribute of textAreaID
-     *@return {Object} HTML textArea div
-     */
-    var clearTextWrapper = function(textAreaID){
-      //convert from JSInterpreter primitive to standard JavaScript String
-      textAreaID = textAreaID ? textAreaID.toString() : '';
-      var textArea;
-      //uses JSInterpreter createPrimitive method to access the DOM
-      myInterpreter.createPrimitive(textArea = document.getElementById(textAreaID));
-      while (textArea.hasChildNodes()) {
-        myInterpreter.createPrimitive(textArea.removeChild(textArea.lastChild));
-      };
-      return myInterpreter.createPrimitive(textArea);
-    };
-    //denotes to the interpreter that upon calls to clearText, it should execute the wrapper function defined.
-    myInterpreter.setProperty(scope, 'clearText', myInterpreter.createNativeFunction(clearTextWrapper));
-
-    /** appendText to the given div within JSInterpreter
-     * @param {String, String, String} 
-     *@return {Object} HTML textArea div
-     */
-    var appendTextWrapper = function(elementType, text, textAreaID){
-      text = text ? text.toString() : '';
-      elementType = elementType ? elementType.toString() : '';
-      textAreaID = textAreaID ? textAreaID.toString() : '';
-
-      var node;
-      var textnode;
-      var textArea;
-      myInterpreter.createPrimitive(node = document.createElement(elementType));                 
-      myInterpreter.createPrimitive(textnode = document.createTextNode(text));  
-      myInterpreter.createPrimitive(textArea = document.getElementById(textAreaID));
-      myInterpreter.createPrimitive(node.appendChild(textnode));                              // Append the text to element
-      myInterpreter.createPrimitive(document.getElementById(textAreaID).appendChild(node)); 
-      return myInterpreter.createPrimitive(textArea);   // Append <li> to <ul> with id="myList"
-    }
-    myInterpreter.setProperty(scope, 'appendText', myInterpreter.createNativeFunction(appendTextWrapper));
-
-    //Speech Synthesis blocks
-
-    /** speak
-     * @param {String, function}
-     */
-    var speechWrapper = function(wordsToSay, callback){
-      wordsToSay = wordsToSay ? wordsToSay.toString() : '';
-      if ('speechSynthesis' in window) {
-        msg.text = wordsToSay;
-        window.speechSynthesis.speak(msg);
-      } else {
-        console.log("speechSynthesis not found. Text to speech capability under Web Speech API not supported.")
-      }
-      msg.onend = function(e) {
-        callback();
-      };
-    };
-    myInterpreter.setProperty(scope, 'globalSay', myInterpreter.createAsyncFunction(speechWrapper)); 
-    
-    //gets voices from the window
-    var getVoicesWrapper = function() {
-      return myInterpreter.createPrimitive(window.speechSynthesis.getVoices());
-    };
-    myInterpreter.setProperty(scope, 'getVoices',
-        myInterpreter.createNativeFunction(getVoicesWrapper));
-
-    /** set voices
-     * @param {number} assumes an integer
-     */
-    var setVoiceWrapper = function(newVoiceIndex) {
-      return myInterpreter.createPrimitive(msg.voice = voices[newVoiceIndex]);
-    };
-    myInterpreter.setProperty(scope, 'setVoice',
-        myInterpreter.createNativeFunction(setVoiceWrapper));
-
-    /** set volume
-     * @param {number} assumes an number between 0 and 1
-     */
-    var setVolumeWrapper = function(newVolume) {
-      return myInterpreter.createPrimitive(msg.volume = newVolume);
-    };   
-    myInterpreter.setProperty(scope, 'setVolume',
-        myInterpreter.createNativeFunction(setVolumeWrapper));    
-
-    /** set rate
-     * @param {number} assumes an number between .1 and 10
-     */
-    var setRateWrapper = function(newRate) {
-      return myInterpreter.createPrimitive(msg.rate = newRate);
-    };   
-    myInterpreter.setProperty(scope, 'setRate',
-        myInterpreter.createNativeFunction(setRateWrapper));    
-  };
-  //initializes myInterpreter
-  var myInterpreter = new Interpreter(code,initFunc);
-  //runs myInterpreter
-  runButton(myInterpreter);
-};
-
-/**
- * Taken from JS Interpreter example
- * @param {Interpreter} myInterpreter The interpreter that is initialized and will run the code.
- */
-var runButton = function(myInterpreter) {
-  if (myInterpreter.run()) {
-    // Ran until an async call.  Give this call a chance to run. Then start running again later.
-    setTimeout(runButton, 10, myInterpreter);
-  }
 };
 
 /**
@@ -295,8 +44,290 @@ var logMessage = function(myInterpreter, message) {
 };
 
 /**
+ * Taken from JS Interpreter example.
+ * Runs the JSInterpreter such that asynchronous functions may work properly.
+ *
+ * @param {Interpreter} myInterpreter The interpreter that is initialized and
+ * will run the code.
+ */
+var runButton = function(myInterpreter) {
+  if (myInterpreter.run()) {
+    // Ran until an async call.  Give this call a chance to run. Then start
+    //running again later.
+    setTimeout(runButton, 10, myInterpreter);
+  }
+};
+
+/**
+ * Generate JavaScript code and run it using the JS Interpreter, prints code to
+ * console for debugging. Defines wrappers (synchronously and asynchronously) to
+ * handle certain blocks that cannot be handled by the JS Interpreter
+ * internally.
+ * NOTE: If the wrapper functions are moved outside of runCode, then
+ * myInterpreter is not in scope. It needs to be a local because it needs to be
+ * recreated each time to allow for changes to code, and myInterpreter can't be
+ * passed as an argument because the order and type of arguments is defined by
+ * JS Interpreter.
+ */
+var runCode = function() {
+  var code = Blockly.JavaScript.workspaceToCode(workspace);
+  window.console.log(code);
+
+  //used to define wrappers for myInterpreter
+  var initFunc = function(myInterpreter,scope) {
+
+    /**
+     * Wrapper to define alert. Taken from JS Interpreter documentation on
+     * Blockly developer site.
+     *
+     * @param {String} text to be displayed
+     */
+    var alertWrapper = function(text) {
+      text = text ? text.toString() : '';
+      myInterpreter.createPrimitive(alert(text));
+    };
+    myInterpreter.setProperty(scope, 'alert',
+        myInterpreter.createNativeFunction(alertWrapper));
+
+    //Listen blocks
+
+    /**
+     * Wrapper to return a boolean if what the user says matches word. Uses JS
+     * Interpreter to make this an asynchronous function so that execution
+     * blocks until the user says a word and the word is processed.
+     * Assumes word has been formatted to be in lower case with no extraneous
+     * characters (using formatText).
+     * Used in listen_if and listen_bool. Sends callback to JS interpreter true
+     * if the word the user says equals word, and false otherwise.
+     *
+     * @param {String} word The word to be compared against
+     * @param {fuction} callback The callback used by JS Interpreter to resume
+     * execution
+     */
+    var listenBranchWrapper = function(word, callback) {
+      word = word ? word.toString() : '';
+      var localRecognizer = new SpeechRecognition();
+      updateGrammars(localRecognizer);
+
+      localRecognizer.onresult = function() {
+        var speechResult = formatText(event.results[0][0].transcript);
+        logMessage(myInterpreter, 'You said: \"' + speechResult + '\"\n');
+        callback(myInterpreter.createPrimitive(speechResult == word));
+      };
+      localRecognizer.onnomatch = function() {
+        logMessage(myInterpreter,"Done listening. Didn't hear anything.");
+        callback(myInterpreter.createPrimitive(false));
+      };
+      localRecognizer.onerror = function() {
+        logMessage(myInterpreter,"Done listening. Error.");
+        callback(myInterpreter.createPrimitive(false));
+      };
+      localRecognizer.start();
+        logMessage(myInterpreter,"Listening...");
+    };
+    myInterpreter.setProperty(scope,'listen_branch',
+      myInterpreter.createAsyncFunction(listenBranchWrapper));
+
+    /**
+     * Wrapper to return the string the user said. Uses JS Interpreter to make
+     * this an asynchronous function so that execution blocks until the user
+     * says a word and the word is processed. Used for listen_text block. It
+     * feeds the string the user spoke into the callback.
+     *
+     * @param {function} callback - Used by JS Interpreter to resume execution
+     * after blocking. During runtime, the callback is provided by JSInterpeter
+     */
+    var listenTextWrapper = function(callback) {
+      var localRecognizer = new SpeechRecognition();
+      updateGrammars(localRecognizer);
+
+      localRecognizer.onresult = function() {
+        var speechResult = event.results[0][0].transcript;
+        logMessage(myInterpreter, 'You said: \"' + speechResult + '\"');
+        callback(myInterpreter.createPrimitive(speechResult));
+      };
+      localRecognizer.onnomatch = function() {
+        logMessage(myInterpreter,"Done listening. No match found.");
+        callback(myInterpreter.createPrimitive(false));
+      };
+      localRecognizer.onerror = function() {
+        logMessage(myInterpreter,"Done listening. Error.");
+        callback(myInterpreter.createPrimitive(false));
+      };
+
+      localRecognizer.start();
+      logMessage(myInterpreter,"Listening...");
+    };
+    myInterpreter.setProperty(scope,'listen_text',
+        myInterpreter.createAsyncFunction(listenTextWrapper));
+
+    //Display blocks
+
+    /**
+     * Wrapper to update the displayed image in HTML div element displayPic.
+     * Needs to be done in wrapper because JS Interpreter can't access
+     * displayPic internally. Used in display_img.
+     *
+     * @param {String} url The URL of the picture to be displayed.
+     */
+    var imageWrapper = function(url) {
+      url = url ? url.toString() : '';
+      myInterpreter.createPrimitive(
+          window.document.getElementById('displayPic').src = url);
+    };
+    myInterpreter.setProperty(scope, 'displayImage',
+        myInterpreter.createNativeFunction(imageWrapper));
+
+    /**
+     * Wrapper to pause execution for a certain number of milliseconds and then
+     * resume execution. Uses JS Interpreter to make this an asynchronous
+     * function so that execution blocks until the user says a word and the word
+     * is processed. Used in pause.
+     *
+     * @param {float} time - Number of milliseconds to pause execution
+     * @param {function} callback - Used by JS Interpreter to resume execution
+     * after blocking.
+     */
+    var pauseWrapper = function(time,callback) {
+      time = time ? time.toString() : '';
+      var timeVar = parseInt(time);
+      window.console.log(timeVar);
+      var resume = function() {
+        callback();
+      };
+      myInterpreter.createPrimitive(window.setTimeout(resume,timeVar));
+    };
+    myInterpreter.setProperty(scope, 'pause',
+        myInterpreter.createAsyncFunction(pauseWrapper));
+
+    /**
+     * Wrapper to clear the textArea div.
+     *
+     * @param {String} textAreaID - id attribute of textAreaID
+     * @return {Element} textArea - HTML div element that is the textArea
+     */
+    var clearTextWrapper = function(textAreaID) {
+      //convert from JS Interpreter primitive to standard JavaScript String
+      textAreaID = textAreaID ? textAreaID.toString() : '';
+      var textArea;
+      //uses JS Interpreter createPrimitive method to access the DOM
+      myInterpreter.createPrimitive(textArea = document.getElementById(textAreaID));
+      while (textArea.hasChildNodes()) {
+        myInterpreter.createPrimitive(textArea.removeChild(textArea.lastChild));
+      }
+      return myInterpreter.createPrimitive(textArea);
+    };
+    //denotes to the interpreter that upon calls to clearText, it should execute the wrapper function defined.
+    myInterpreter.setProperty(scope, 'clearText', myInterpreter.createNativeFunction(clearTextWrapper));
+
+    /**
+     * Wrapper to append text to the given div within JS Interpreter.
+     *
+     * @param {String} elementType - type of element to with which to
+     *    encapsulate text e.g. "p" or "h3"
+     * @param {String} text - text to append to the text area
+     * @param {String} textAreaID - id of text area div to which we append text
+     * @return {Element} textArea - HTML textArea div
+     */
+    var appendTextWrapper = function(elementType, text, textAreaID) {
+      text = text ? text.toString() : '';
+      elementType = elementType ? elementType.toString() : '';
+      textAreaID = textAreaID ? textAreaID.toString() : '';
+
+      var node;
+      var textnode;
+      var textArea;
+      myInterpreter.createPrimitive(node = document.createElement(elementType));
+      myInterpreter.createPrimitive(textnode = document.createTextNode(text));
+      myInterpreter.createPrimitive(textArea =
+          document.getElementById(textAreaID));
+      myInterpreter.createPrimitive(node.appendChild(textnode));
+      myInterpreter.createPrimitive(
+          document.getElementById(textAreaID).appendChild(node));
+      return myInterpreter.createPrimitive(textArea);
+    };
+    myInterpreter.setProperty(scope, 'appendText',
+        myInterpreter.createNativeFunction(appendTextWrapper));
+
+    //Speech Synthesis blocks
+
+    /**
+     * Wrapper to use speech synthesis to say aloud text provided by the user.
+     * Uses JS Interpreter to make this an asynchronous function so that
+     * execution blocks while the speech synthesizer is speaking.
+     * and the word is processed. Used in pause.
+     *
+     * @param {String} wordsToSay - Text for speech synthesizer to say aloud
+     * @param {function} callback - Used by JS Interpreter to resume execution
+     *    after blocking.
+     */
+    var speechWrapper = function(wordsToSay, callback) {
+      wordsToSay = wordsToSay ? wordsToSay.toString() : '';
+      if ('speechSynthesis' in window) {
+        msg.text = wordsToSay;
+        window.speechSynthesis.speak(msg);
+      } else {
+        logMessage("speechSynthesis not found. Text to speech capability under Web Speech API not supported.");
+      }
+      msg.onend = function(e) {
+        callback();
+      };
+    };
+    myInterpreter.setProperty(scope, 'globalSay', myInterpreter.createAsyncFunction(speechWrapper));
+
+    /**
+     * Wrapper to get voices available for speech synthesis from the window.
+     */
+    var getVoicesWrapper = function() {
+      myInterpreter.createPrimitive(window.speechSynthesis.getVoices());
+    };
+    myInterpreter.setProperty(scope, 'getVoices',
+        myInterpreter.createNativeFunction(getVoicesWrapper));
+
+    /**
+     * Wrapper to get voices available for speech synthesis from the window.
+     *
+     * @param {number} newVoiceIndex - index within the voices array at which
+     * the user-selected voices lives.
+     */
+    var setVoiceWrapper = function(newVoiceIndex) {
+      //voices is defined in the blocks.js file that defines the set_voice block
+      myInterpreter.createPrimitive(msg.voice = voices[newVoiceIndex]);
+    };
+    myInterpreter.setProperty(scope, 'setVoice',
+        myInterpreter.createNativeFunction(setVoiceWrapper));
+
+    /**
+     * Wrapper to set the volume of the speech synthesizer.
+     *
+     * @param {number} newVolume - a number n, where 0 <= n <= 1.
+     */
+    var setVolumeWrapper = function(newVolume) {
+      myInterpreter.createPrimitive(msg.volume = newVolume);
+    };
+    myInterpreter.setProperty(scope, 'setVolume',
+        myInterpreter.createNativeFunction(setVolumeWrapper));
+
+    /**
+     * Wrapper to set the rate of speech for the speech synthesizer.
+     *
+     * @param {number} newRate - a number n, where .1 <= n <= 10.
+     */
+    var setRateWrapper = function(newRate) {
+      myInterpreter.createPrimitive(msg.rate = newRate);
+    };
+    myInterpreter.setProperty(scope, 'setRate',
+        myInterpreter.createNativeFunction(setRateWrapper));
+  };
+  //initializes myInterpreter
+  var myInterpreter = new Interpreter(code,initFunc);
+  //runs myInterpreter
+  runButton(myInterpreter);
+};
+
+/**
  * Add a word that the recognizer should be able to recognize from the user. Called from block code.
- * @param {string} word The word to be added to the list of recognizable words. 
+ * @param {string} word The word to be added to the list of recognizable words.
  */
 
 var addRecognizableWord = function(word) {
@@ -305,6 +336,7 @@ var addRecognizableWord = function(word) {
 
 /**
  * Uses the recognizableWords to generate a string to give to the recognizer in updateGrammars.
+ *
  * @return {string} Returns the grammar string formatted correctly so that it can update the grammar of a
  * recognizer.
  */
@@ -322,7 +354,7 @@ var convertRecognizableWordsToString = function() {
 
 /**
  * Takes as an argument the recognizer to update. Sets the settings using the grammar string and sets the
- * language to US English. 
+ * language to US English.
  * TODO(edauterman): Should we add more choices for language for possible i18n?
  * @param {Recognizer} myRecognizer The recognizer to be updated.
  */
@@ -338,17 +370,16 @@ var updateGrammars = function(myRecognizer) {
 };
 
 /**
- * Given a String, gets rid of punctuation and capitalization--all words are left lowercase and separated 
+ * Given a String, gets rid of punctuation and capitalization--all words are left lowercase and separated
  * by a single space
- * @param {String} text Input for formatting
+ *
+ * @param {String} text input for formatting
  * @return {String} Formatted text
  */
-  var formatText = function (text){
-    // if(text !== undefined){
-      var punctuationless = text.replace(/[.,\/#!$%\^&\*;:{}—=\-_`~()]/g," "); //remove punctuation
-
-      var finalString = punctuationless.replace(/\s\s+/g, ' '); //replace all spaces with a single space
-      var finalString = finalString.toLowerCase().trim(); //make all lowercase and get rid of extra surrounding white space
-    // }
-    return finalString; 
-  };
+var formatText = function (text){
+  var punctuationless = text.replace(/[.,\/#!$%\^&\*;:{}—=\-_`~()]/g," ");
+  //replace all spaces with a single space
+  var finalString = punctuationless.replace(/\s\s+/g, ' ');
+  var finalString = finalString.toLowerCase().trim();
+  return finalString;
+};

--- a/demos/speech/speech.js
+++ b/demos/speech/speech.js
@@ -211,7 +211,7 @@ speech.runCode = function() {
      * Wrapper to clear the textArea div.
      *
      * @param {String} textAreaID - id attribute of textAreaID
-     * @return {Element} textArea - HTML div element that is the textArea
+     * @return {Element} HTML div element that is the textArea
      */
     var clearTextWrapper = function(textAreaID) {
       //convert from JS Interpreter primitive to standard JavaScript String
@@ -237,7 +237,7 @@ speech.runCode = function() {
      *    encapsulate text e.g. "p" or "h3"
      * @param {String} text - text to append to the text area
      * @param {String} textAreaID - id of text area div to which we append text
-     * @return {Element} textArea - HTML textArea div
+     * @return {Element} HTML textArea div
      */
     var appendTextWrapper = function(elementType, text, textAreaID) {
       text = text ? text.toString() : '';
@@ -352,7 +352,7 @@ speech.addRecognizableWord = function(word) {
  * Uses the recognizableWords to generate a string to give to the recognizer in
  * updateGrammars.
  *
- * @return {String} grammarString - the grammar string formatted correctly
+ * @return {String} the grammar string formatted correctly
  * so that it can update the grammar of a recognizer.
  */
 speech.convertRecognizableWordsToString = function() {
@@ -391,7 +391,7 @@ speech.createSpeechRecognizer = function() {
  * left lowercase and separated by a single space.
  *
  * @param {String} text - text input for formatting
- * @return {String} finalString - formatted text
+ * @return {String} formatted text
  */
 speech.formatText = function(text){
   var punctuationless = text.replace(/[.,\/#!$%\^&\*;:{}—=\-_`~()]/g," ");

--- a/demos/speech/speech.js
+++ b/demos/speech/speech.js
@@ -1,5 +1,13 @@
 /**
- * @fileoverview TODO(quacht)
+ * @fileoverview initializes the speech recongition and synthesis objects,
+ * defines helper functions for the demo and  functions to run custom
+ * blocks' code using JS Interpreter. Much of this exists in the form of wrapper
+ * functions. This file depends on the index.html (some functions edit the DOM),
+ * blocks.js (where the blocks' init functions and the global voices
+ * variable is defined), and blockgenerators.js (where the block generate code
+ * is defined).
+ *
+ * @author edauterman, quacht
  */
 
 'use strict';
@@ -18,7 +26,7 @@ speech.SpeechGrammarList = webkitSpeechGrammarList;
 speech.SpeechRecognitionEvent = webkitSpeechRecognitionEvent;
 
 //allows for portability across different browsers
-// TODO(quacht): going to talk to Neil about why the implementation below is
+// TODO(quacht): waiting to hear back from  Neil about why the implementation below is
 //causing issues.
 // speech.SpeechRecognition = SpeechRecognition || webkitSpeechRecognition;
 // speech.SpeechGrammarList = SpeechGrammarList || webkitSpeechGrammarList;


### PR DESCRIPTION
Initially, speech_set_voice was only declared after the window.speechSynthesis.onvoiceschanged event was fired so that we could access the list of the voices provided by the window. This was necessary for Chrome because if you tried to access the voices in the browser without waiting for the event, an empty voice list would be returned. This isn't a problem in Mozilla--immediately calling window.speechSynthesis.getVoices() returns the voices. 

Also got rid of some indentation issues and trailing spaces.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quachtina96/blockly/4)

<!-- Reviewable:end -->
