### PR TITLE
moved CSS out of index.html

### DIFF
--- a/demos/blockfactory/factory.css
+++ b/demos/blockfactory/factory.css
@@ -93,3 +93,37 @@ button, .buttonStyle {
 #linkButton {
   display: none;
 }
+
+#blockLibraryContainer {
+   vertical-align: bottom;
+}
+
+#blockLibraryControls {
+  vertical-align: middle;
+  text-align: right;
+}
+
+#previewContainer {
+  vertical-align: bottom;
+}
+
+#buttonContainer {
+  vertical-align: middle;
+  text-align: right;
+}
+
+#files {
+  visibility: hidden;
+  position: absolute;
+}
+
+#toolbox {
+  display: none;
+}
+
+#blocklyWorkspaceContainer {
+  padding: 2px;
+  width: 50%;
+  height: 95%;
+}
+

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -25,14 +25,14 @@
       <td width="50%" height="5%">
         <table>
           <tr id="blockLibrary">
-            <td style="vertical-align: bottom;">
+            <td id="blockLibraryContainer">
             <span>
               <h3>Block Library:</h3>
               <select id="blockLibraryDropdown" onChange="BlockLibrary.selectHandler(this);">
               </select>
             </span>
             </td>
-            <td style="vertical-align: middle; text-align: right;">
+            <td id="blockLibraryControls">
             <button id="saveToBlockLibraryButton" title="Save block xml to a local file.">
               <span>Save to Block Library</span>
             </button>
@@ -45,7 +45,7 @@
             </td>
           </tr>
           <tr>
-            <td style="vertical-align: bottom;">
+            <td id="previewContainer">
               <h3>Preview:
                 <select id="direction">
                   <option value="ltr">LTR</option>
@@ -53,16 +53,18 @@
                 </select>
               </h3>
             </td>
-            <td style="vertical-align: middle; text-align: right;">
+            <td id="buttonContainer">
               <button id="linkButton" title="Save and link to blocks.">
                 <img src="link.png" height="21" width="21">
               </button>
               <button id="linkButton" title="Save and link to blocks.">
                 <img src="link.png" height="21" width="21">
               </button>
-              <label for="files" class="buttonStyle"> <span class=>Import block</span></label>
-              <input style="visibility: hidden; position: absolute;" id="files"  type="file"
-                     name="files" accept="application/xml">
+              <label for="files" class="buttonStyle">
+                <span class=>Import block</span>
+              </label>
+              <input id="files"  type="file" name="files"
+                  accept="application/xml">
               <button id="localSaveButton" title="Save block xml to a local file.">
                 <span>Download block</span>
               </button>
@@ -75,7 +77,7 @@
       </td>
     </tr>
     <tr>
-      <td width="50%" height="95%" style="padding: 2px;">
+      <td id="blocklyWorkspaceContainer">
         <div id="blockly"></div>
         <div id="blocklyMask"></div>
       </td>
@@ -132,7 +134,7 @@
         </table>
       </td>
   </table>
-  <xml id="toolbox" style="display: none">
+  <xml id="toolbox">
     <category name="Input">
       <block type="input_value">
         <value name="TYPE">


### PR DESCRIPTION
Created a new file: factory.css to contain most of the CSS and styling integrated into index.html
Height and width attributes of various HTML elements without IDs still live in index.html.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quachtina96/blockly/6)

<!-- Reviewable:end -->
