### PR TITLE
Block Factory Expansion: Generating Block Definitions for Blocks with Connections

### DIFF
--- a/demos/blockfactory/block_exporter_tools.js
+++ b/demos/blockfactory/block_exporter_tools.js
@@ -86,7 +86,7 @@ BlockExporterTools.prototype.getBlockDefs =
           if (rootBlock) {
             // Generate the block's definition.
             var code = BlockFactory.getBlockDefinition(blockType, rootBlock,
-                definitionFormat);
+                definitionFormat, this.hiddenWorkspace);
             // Add block's definition to the definitions to return.
           } else {
             // Append warning comment and write to console.

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -113,18 +113,11 @@
               <button id="linkButton" title="Save and link to blocks.">
                 <img src="link.png" height="21" width="21">
               </button>
-              <label for="defFiles" class="buttonStyle">
-                <span class=>Import block defs</span>
-              </label>
-              <input id="defFiles" type="file" name="defFiles"
-                  accept="application/xml" style="display:none">
-
               <label for="files" class="buttonStyle">
                 <span class=>Import block</span>
               </label>
               <input id="files" type="file" name="files"
                   accept="application/xml">
-
               <button id="localSaveButton" title="Save block xml to a local file.">
                 <span>Download block</span>
               </button>

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -113,11 +113,18 @@
               <button id="linkButton" title="Save and link to blocks.">
                 <img src="link.png" height="21" width="21">
               </button>
+              <label for="defFiles" class="buttonStyle">
+                <span class=>Import block defs</span>
+              </label>
+              <input id="defFiles" type="file" name="defFiles"
+                  accept="application/xml" style="display:none">
+
               <label for="files" class="buttonStyle">
                 <span class=>Import block</span>
               </label>
               <input id="files" type="file" name="files"
                   accept="application/xml">
+
               <button id="localSaveButton" title="Save block xml to a local file.">
                 <span>Download block</span>
               </button>


### PR DESCRIPTION
Previously, generating the block definition depended on functions that acted on specifically BlockFactory’s workspace rather than any workspace provided as a parameter. This led to errors loading the page when the Block Exporter was generating block definitions for blocks with connections. 

Functions shared between factory.js and Block Exporter Tools are now not specific to single workspace.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quachtina96/blockly/12)

<!-- Reviewable:end -->
