### PR TITLE
Block Exporter #2: Clear Selected Blocks

### DIFF
--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -108,3 +108,18 @@ BlockExporterController.prototype.updateToolbox = function(opt_toolboxXml) {
   // Render the toolbox in the selector workspace.
   this.view.renderToolbox(updatedToolbox);
 };
+
+/**
+ * Tied to the 'Clear Selected Blocks' button in the Block Exporter.
+ * Deselects all blocks on the selector workspace by deleting them and updating
+ * text accordingly.
+ */
+BlockExporterController.prototype.clearSelectedBlocks = function() {
+  // Clear selector workspace.
+  this.view.clearSelectorWorkspace();
+  // Edit helper text
+  this.view.updateHelperText('No blocks selected. Drag block into workspace' +
+      ' to select.');
+  // TODO(quacht): After mergeing enable/disable blocks, throw delete events
+  // for each block.
+};

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -37,7 +37,7 @@ BlockExporterController = function(blockLibStorage) {
  * @return {!Array.<string>} Types of blocks in workspace.
  */
 BlockExporterController.prototype.getSelectedBlockTypes_ = function() {
-  var selectedBlocks = this.view.selectorWorkspace.getAllBlocks();
+  var selectedBlocks = this.view.getSelectedBlocks();
   var blockTypes = [];
   for (var i = 0; i < selectedBlocks.length; i++) {
     blockTypes.push(selectedBlocks[i].type);
@@ -94,7 +94,8 @@ BlockExporterController.prototype.exportBlocks = function() {
 };
 
 /**
- * Update the Exporter's toolbox.
+ * Update the Exporter's toolbox with either the given toolbox xml or toolbox
+ * xml generated from blocks stored in block library.
  *
  * @param {Element} opt_toolboxXml - Xml to define toolbox of the selector
  *    workspace.
@@ -102,6 +103,8 @@ BlockExporterController.prototype.exportBlocks = function() {
 BlockExporterController.prototype.updateToolbox = function(opt_toolboxXml) {
   var updatedToolbox = opt_toolboxXml ||
       this.tools.generateToolboxFromLibrary(this.blockLibStorage);
+  // Update the view's toolbox.
   this.view.setToolbox(updatedToolbox);
+  // Render the toolbox in the selector workspace.
   this.view.renderToolbox(updatedToolbox);
 };

--- a/demos/blockfactory/block_exporter_view.js
+++ b/demos/blockfactory/block_exporter_view.js
@@ -76,5 +76,20 @@ BlockExporterView.prototype.updateHelperText = function(newText, opt_append) {
   }
 };
 
+/**
+ * Clears selector workspace.
+ */
+BlockExporterView.prototype.clearSelectorWorkspace = function() {
+  this.selectorWorkspace.clear();
+};
+
+/**
+ * Returns array of selected blocks.
+ *
+ * @return {Array.<Blockly.Block>} Array of all blocks in selector workspace.
+ */
+BlockExporterView.prototype.getSelectedBlocks = function() {
+  return this.selectorWorkspace.getAllBlocks();
+};
 
 

--- a/demos/blockfactory/block_factory_expansion.js
+++ b/demos/blockfactory/block_factory_expansion.js
@@ -134,6 +134,11 @@ BlockFactoryExpansion.init = function() {
         BlockFactoryExpansion.exporter.exportBlocks();
       });
 
+  document.getElementById('clearSelectedButton').addEventListener('click',
+      function() {
+        BlockFactoryExpansion.exporter.clearSelectedBlocks();
+      });
+
   /**
    * Add tab handlers to allow switching between the Block Factory
    * tab and the Block Exporter tab.

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -66,6 +66,7 @@
           <br>
       </form>
         <button id="exporterSubmitButton"> Export </button>
+        <button id="clearSelectedButton"> Clear Selected Blocks </button>
     </div>
   </div>
 


### PR DESCRIPTION
In the Export Settings menu, allow the user to clear all blocks by pressing a button.
Also edits the helper text accordingly.
<img width="1203" alt="screen shot 2016-08-01 at 3 23 03 pm" src="https://cloud.githubusercontent.com/assets/10423718/17310935/746853c0-57fc-11e6-8e8f-c051746664b3.png">
<img width="1173" alt="screen shot 2016-08-01 at 3 23 18 pm" src="https://cloud.githubusercontent.com/assets/10423718/17310942/7b8ab8be-57fc-11e6-9016-300459c7c3e2.png">

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quachtina96/blockly/13)

<!-- Reviewable:end -->
