### PR TITLE
Block Exporter #3: Disable/Enable Blocks when Selected

### DIFF
--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -111,16 +111,16 @@ BlockExporterController.prototype.updateToolbox = function(opt_toolboxXml) {
  * Enable or Disable block in selector workspace's toolbox.
  *
  * @param {!string} blockType - Type of block to disable or enable.
- * @param {!boolean} disable - True to disable the block, false to enable block.
+ * @param {!boolean} enable - True to enable the block, false to disable block.
  */
-BlockExporterController.prototype.setBlockDisabled =
-    function(blockType, disable) {
+BlockExporterController.prototype.setBlockEnabled =
+    function(blockType, enable) {
   var toolboxXml = this.view.toolbox;
   var category = goog.dom.xml.selectSingleNode(toolboxXml,
       '//category[@name="' + blockType + '"]');
   var block = goog.dom.getFirstElementChild(category);
-  // Disable block.
-  goog.dom.xml.setAttributes(block, {disabled: disable});
+  // Enable block.
+  goog.dom.xml.setAttributes(block, {disabled: !enable});
 };
 
 /**
@@ -160,7 +160,7 @@ BlockExporterController.prototype.onSelectBlockForExport_ = function(event) {
     var blockType = block.type;
     // Disable the selected block. Users can only export one copy of starter
     // code per block.
-    this.setBlockDisabled(blockType, true);
+    this.setBlockEnabled(blockType, false);
     // Show currently selected blocks in helper text.
     this.view.listSelectedBlocks(this.getSelectedBlockTypes_());
   }
@@ -181,9 +181,8 @@ BlockExporterController.prototype.onDeselectBlockForExport_ = function(event) {
     var deletedBlockXml = event.oldXml;
     var blockType = deletedBlockXml.getAttribute('type');
     // Enable the deselected block.
-    this.setBlockDisabled(blockType, false);
+    this.setBlockEnabled(blockType, true);
     // Show currently selected blocks in helper text.
     this.view.listSelectedBlocks(this.getSelectedBlockTypes_());
   }
 };
-

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -194,18 +194,35 @@ BlockExporterController.prototype.enableBlock = function(blockType) {
 };
 
 BlockExporterController.prototype.onSelectBlockForExport = function(event) {
-  // Disable the selected block. Users can only export one copy of starter code
-  // per block.
-  // Edit helper text (currently selected)
+  // BUG: this is currently undefined
+  if (event.type == Blockly.Events.CREATE) {
+    // Get type of block created.
+    var blockType = this.view.selectorWorkspace.getBlockById(event.blockId);
+    // Disable the selected block. Users can only export one copy of starter code
+    // per block.
+    this.disableBlock(blockType);
+    // Edit helper text (currently selected)
+    this.view.updateHelperText('Currently Selected:' +
+        this.getSelectedBlockTypes());
+  }
 };
 
 BlockExporterController.prototype.onDeselectBlockForExport = function(event) {
-  // Enable the selected block. Users can only export one copy of starter code
-  // per block.
-  // Edit helper text (currently selected)
+  // this is currently undefined.
+  if (event.type == Blockly.Events.DELETE) {
+    // Get type of block created.
+    var blockType = this.view.selectorWorkspace.getBlockById(event.blockId);
+    // Enable the deselected block.
+    this.enableBlock(blockType);
+    // Edit helper text (currently selected)
+    this.view.updateHelperText('Currently Selected:' +
+        this.getSelectedBlockTypes());
+  }
 };
 
-// // need to add change listener to the view object
-// this.view.selectorWorkspace.addChangeListener(onSelectBlockForExport);
-// this.view.selectorWorkspace.addChangeListener(onDeselectBlockForExport);
+BlockExporterController.prototype.addChangeListeners = function() {
+  this.view.selectorWorkspace.addChangeListener(this.onSelectBlockForExport);
+  this.view.selectorWorkspace.addChangeListener(this.onDeselectBlockForExport);
+};
+
 

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -110,7 +110,7 @@ BlockExporterController.prototype.updateToolbox = function(opt_toolboxXml) {
 };
 
 /**
- * Disable block in selector workspace's toolbox.
+ * Enable or Disable block in selector workspace's toolbox.
  *
  * @param {string} blockType - type of block to disable
  */
@@ -136,17 +136,38 @@ BlockExporterController.prototype.enableBlock = function(blockType) {
   var category = goog.dom.xml.selectSingleNode(toolboxXml,
       '//category[@name="' + blockType + '"]');
   var block = goog.dom.getFirstElementChild(category);
-  // Remove disabled block xml from toolbox.
-  goog.dom.removeNode(block);
-  // Get enabled block xml and add to toolbox, replacing disabled block xml
-  // within category.
-  var enabledBlock = this.disabledBlocks[blockType];
-  goog.dom.appendChild(category, enabledBlock);
-  // Remove block from map of disabled blocks.
-  delete this.disabledBlocks[blockType];
-  // Update toolbox.
-  this.updateToolbox(toolboxXml);
+  goog.dom.xml.setAttributes(block, {disabled: false});
+  // // Remove disabled block xml from toolbox.
+  // goog.dom.removeNode(block);
+  // // Get enabled block xml and add to toolbox, replacing disabled block xml
+  // // within category.
+  // var enabledBlock = this.disabledBlocks[blockType];
+  // goog.dom.appendChild(category, enabledBlock);
+  // // Remove block from map of disabled blocks.
+  // delete this.disabledBlocks[blockType];
+  // // Update toolbox.
+  // this.updateToolbox(toolboxXml);
 };
+
+/**
+ * Add change listeners to the exporter's selector workspace.
+ */
+BlockExporterController.prototype.addChangeListenersToSelectorWorkspace
+    = function() {
+      // Assign the BlockExporterController to 'self' to be called in the change
+      // listeners. This keeps it in scope--otherwise, 'this' in the change
+      // listeners refers to the wrong thing.
+      var self = this;
+      var selector = this.view.selectorWorkspace;
+      selector.addChangeListener(
+        function(event) {
+          self.onSelectBlockForExport(event);
+        });
+      selector.addChangeListener(
+        function(event) {
+          self.onDeselectBlockForExport(event);
+        });
+    };
 
 /**
  * Callback function for when a user selects a block for export in selector
@@ -192,22 +213,3 @@ BlockExporterController.prototype.onDeselectBlockForExport = function(event) {
   }
 };
 
-/**
- * Add change listeners to the exporter's selector workspace.
- */
-BlockExporterController.prototype.addChangeListenersToSelectorWorkspace
-    = function() {
-      // Assign the BlockExporterController to 'self' to be called in the change
-      // listeners. This keeps it in scope--otherwise, 'this' in the change
-      // listeners refers to the wrong thing.
-      var self = this;
-      var selector = this.view.selectorWorkspace;
-      selector.addChangeListener(
-        function(event) {
-          self.onSelectBlockForExport(event);
-        });
-      selector.addChangeListener(
-        function(event) {
-          self.onDeselectBlockForExport(event);
-        });
-    };

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -166,7 +166,7 @@ BlockExporterController.prototype.onSelectBlockForExport = function(event) {
     // code per block.
     this.disableBlock(blockType);
     // Edit helper text (currently selected)
-    var selectedBlocksText = this.getSelectedBlockTypes().join(', ');
+    var selectedBlocksText = this.getSelectedBlockTypes_().join(', ');
     this.view.updateHelperText('Currently Selected: ' + selectedBlocksText);
   }
 };
@@ -187,9 +187,27 @@ BlockExporterController.prototype.onDeselectBlockForExport = function(event) {
     // Enable the deselected block.
     this.enableBlock(blockType);
     // Edit helper text (currently selected)
-    var selectedBlocksText = this.getSelectedBlockTypes().join(', ');
+    var selectedBlocksText = this.getSelectedBlockTypes_().join(', ');
     this.view.updateHelperText('Currently Selected: ' + selectedBlocksText);
   }
 };
 
-
+/**
+ * Add change listeners to the exporter's selector workspace.
+ */
+BlockExporterController.prototype.addChangeListenersToSelectorWorkspace
+    = function() {
+      // Assign the BlockExporterController to 'self' to be called in the change
+      // listeners. This keeps it in scope--otherwise, 'this' in the change
+      // listeners refers to the wrong thing.
+      var self = this;
+      var selector = this.view.selectorWorkspace;
+      selector.addChangeListener(
+        function(event) {
+          self.onSelectBlockForExport(event);
+        });
+      selector.addChangeListener(
+        function(event) {
+          self.onDeselectBlockForExport(event);
+        });
+    };

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -135,11 +135,11 @@ BlockExporterController.prototype.addChangeListenersToSelectorWorkspace
   var selector = this.view.selectorWorkspace;
   selector.addChangeListener(
     function(event) {
-      self.onSelectBlockForExport(event);
+      self.onSelectBlockForExport_(event);
     });
   selector.addChangeListener(
     function(event) {
-      self.onDeselectBlockForExport(event);
+      self.onDeselectBlockForExport_(event);
     });
 };
 
@@ -148,10 +148,11 @@ BlockExporterController.prototype.addChangeListenersToSelectorWorkspace
  * workspace. Disables selected block so that the user only exports one
  * copy of starter code per block. Attached to the blockly create event in block
  * factory expansion's init.
+ * @private
  *
  * @param {!Blockly.Events} event - The fired Blockly event.
  */
-BlockExporterController.prototype.onSelectBlockForExport = function(event) {
+BlockExporterController.prototype.onSelectBlockForExport_ = function(event) {
   // The user created a block in selector workspace.
   if (event.type == Blockly.Events.CREATE) {
     // Get type of block created.
@@ -169,10 +170,11 @@ BlockExporterController.prototype.onSelectBlockForExport = function(event) {
  * Callback function for when a user deselects a block in selector
  * workspace by deleting it. Re-enables block so that the user may select it for
  * export
+ * @private
  *
  * @param {!Blockly.Events} event - The fired Blockly event.
  */
-BlockExporterController.prototype.onDeselectBlockForExport = function(event) {
+BlockExporterController.prototype.onDeselectBlockForExport_ = function(event) {
   // The user deleted a block in selector workspace.
   if (event.type == Blockly.Events.DELETE) {
     // Get type of block created.

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -162,7 +162,7 @@ BlockExporterController.prototype.updateToolbox = function(opt_toolboxXml) {
 BlockExporterController.prototype.disableBlock = function(blockType) {
   var toolboxXml = this.view.toolbox;
   var category = goog.dom.xml.selectSingleNode(toolboxXml,
-      '//category[@name=\'' + blockType + '\']');
+      '//category[@name="' + blockType + '"]');
   var block = goog.dom.getFirstElementChild(category);
   // Save enabled block xml.
   var clonedBlock = block.cloneNode(true);
@@ -179,7 +179,7 @@ BlockExporterController.prototype.disableBlock = function(blockType) {
 BlockExporterController.prototype.enableBlock = function(blockType) {
   var toolboxXml = this.view.toolbox;
   var category = goog.dom.xml.selectSingleNode(toolboxXml,
-      '//category[@name=\'' + blockType + '\']');
+      '//category[@name="' + blockType + '"]');
   var block = goog.dom.getFirstElementChild(category);
   // Remove disabled block xml from toolbox.
   goog.dom.removeNode(block);
@@ -197,13 +197,14 @@ BlockExporterController.prototype.onSelectBlockForExport = function(event) {
   // BUG: this is currently undefined
   if (event.type == Blockly.Events.CREATE) {
     // Get type of block created.
-    var blockType = this.view.selectorWorkspace.getBlockById(event.blockId);
+    var block = this.view.selectorWorkspace.getBlockById(event.blockId);
+    var blockType = block.type;
     // Disable the selected block. Users can only export one copy of starter code
     // per block.
     this.disableBlock(blockType);
     // Edit helper text (currently selected)
-    this.view.updateHelperText('Currently Selected:' +
-        this.getSelectedBlockTypes());
+    var selectedBlocksText = this.getSelectedBlockTypes().join(', ');
+    this.view.updateHelperText('Currently Selected: ' + selectedBlocksText);
   }
 };
 
@@ -211,18 +212,14 @@ BlockExporterController.prototype.onDeselectBlockForExport = function(event) {
   // this is currently undefined.
   if (event.type == Blockly.Events.DELETE) {
     // Get type of block created.
-    var blockType = this.view.selectorWorkspace.getBlockById(event.blockId);
+    var deletedBlockXml = event.oldXml;
+    var blockType = deletedBlockXml.getAttribute('type');
     // Enable the deselected block.
     this.enableBlock(blockType);
     // Edit helper text (currently selected)
-    this.view.updateHelperText('Currently Selected:' +
-        this.getSelectedBlockTypes());
+    var selectedBlocksText = this.getSelectedBlockTypes().join(', ');
+    this.view.updateHelperText('Currently Selected: ' + selectedBlocksText);
   }
-};
-
-BlockExporterController.prototype.addChangeListeners = function() {
-  this.view.selectorWorkspace.addChangeListener(this.onSelectBlockForExport);
-  this.view.selectorWorkspace.addChangeListener(this.onDeselectBlockForExport);
 };
 
 

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -151,3 +151,40 @@ BlockExporterController.prototype.updateToolbox = function(opt_toolboxXml) {
   this.view.setToolbox(updatedToolbox);
   this.view.renderToolbox(updatedToolbox);
 };
+
+/**
+ * Disable block in selector workspace's toolbox.
+ *
+ * @param {blockType}
+ */
+BlockExporterController.prototype.disableBlock = function(blockType) {
+  var oldToolboxXml = BlockExporterController.view.toolbox;
+
+  // TODO(quacht): implement
+};
+
+/**
+ * Enable block in selector workspace's toolbox.
+ *
+ * @param {blockType}
+ */
+BlockExporterController.prototype.enableBlock = function(blockType) {
+// TODO(quacht): implement
+};
+
+BlockExporterController.prototype.onSelectBlockForExport = function(event) {
+  // Disable the selected block. Users can only export one copy of starter code
+  // per block.
+  // Edit helper text (currently selected)
+};
+
+BlockExporterController.prototype.onDeselectBlockForExport = function(event) {
+  // Enable the selected block. Users can only export one copy of starter code
+  // per block.
+  // Edit helper text (currently selected)
+};
+
+// need to add change listener to the view object
+BlockExporterController.view.selectorWorkspace.addChangeListener(onSelectBlockForExport);
+BlockExporterController.view.selectorWorkspace.addChangeListener(onDeselectBlockForExport);
+

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -160,9 +160,8 @@ BlockExporterController.prototype.onSelectBlockForExport = function(event) {
     // Disable the selected block. Users can only export one copy of starter
     // code per block.
     this.setBlockDisabled(blockType, true);
-    // Edit helper text (currently selected)
-    var selectedBlocksText = this.getSelectedBlockTypes_().join(', ');
-    this.view.updateHelperText('Currently Selected: ' + selectedBlocksText);
+    // Show currently selected blocks in helper text.
+    this.view.listSelectedBlocks(this.getSelectedBlockTypes_());
   }
 };
 
@@ -181,9 +180,8 @@ BlockExporterController.prototype.onDeselectBlockForExport = function(event) {
     var blockType = deletedBlockXml.getAttribute('type');
     // Enable the deselected block.
     this.setBlockDisabled(blockType, false);
-    // Edit helper text (currently selected)
-    var selectedBlocksText = this.getSelectedBlockTypes_().join(', ');
-    this.view.updateHelperText('Currently Selected: ' + selectedBlocksText);
+    // Show currently selected blocks in helper text.
+    this.view.listSelectedBlocks(this.getSelectedBlockTypes_());
   }
 };
 

--- a/demos/blockfactory/block_exporter_tools.js
+++ b/demos/blockfactory/block_exporter_tools.js
@@ -26,11 +26,12 @@ BlockExporterTools = function() {
   // Create container for hidden workspace
   this.container = goog.dom.createDom('div',
     {
-      'id': 'blockExporterTools_hiddenWorkspace',
-      'display': 'none'
+      'id': 'blockExporterTools_hiddenWorkspace'
     },
     '' // Empty div
     );
+  // Hide the container.
+  this.container.style.display = 'none';
   goog.dom.appendChild(
       document.getElementsByTagName('body')[0], this.container);
   /**

--- a/demos/blockfactory/block_exporter_view.js
+++ b/demos/blockfactory/block_exporter_view.js
@@ -76,5 +76,15 @@ BlockExporterView.prototype.updateHelperText = function(newText, opt_append) {
   }
 };
 
+/**
+ * Updates the helper text to show currently selected blocks.
+ *
+ * @param {!Array} selectedBlockTypes - Array of blocks selected in workspace.
+ */
+BlockExporterView.prototype.listSelectedBlocks = function(selectedBlockTypes) {
+  var selectedBlocksText = selectedBlockTypes.join(', ');
+  this.updateHelperText('Currently Selected: ' + selectedBlocksText);
+};
+
 
 

--- a/demos/blockfactory/block_exporter_view.js
+++ b/demos/blockfactory/block_exporter_view.js
@@ -77,7 +77,7 @@ BlockExporterView.prototype.updateHelperText = function(newText, opt_append) {
 };
 
 /**
- * Updates the helper text to show currently selected blocks.
+ * Updates the helper text to show list of currently selected blocks.
  *
  * @param {!Array} selectedBlockTypes - Array of blocks selected in workspace.
  */

--- a/demos/blockfactory/block_exporter_view.js
+++ b/demos/blockfactory/block_exporter_view.js
@@ -61,7 +61,7 @@ BlockExporterView.prototype.setToolbox = function(toolboxXml) {
  * switching between Block Factory tab and Block Exporter Tab.
  */
 BlockExporterView.prototype.renderToolbox = function() {
-  this.selectorWorkspace.toolbox_.populate_(this.toolbox);
+  this.selectorWorkspace.updateToolbox(this.toolbox);
 };
 
 /**

--- a/demos/blockfactory/block_factory_expansion.js
+++ b/demos/blockfactory/block_factory_expansion.js
@@ -42,6 +42,7 @@ BlockFactoryExpansion.init = function() {
   BlockFactoryExpansion.exporter = new BlockExporterController(
       'blockLibraryExporter', BlockLibrary.Controller.storage);
 
+  BlockFactoryExpansion.exporter.addChangeListeners();
   // Assign button click handlers for Block Exporter.
   document.getElementById('exporterSubmitButton').addEventListener('click',
       function() {

--- a/demos/blockfactory/block_factory_expansion.js
+++ b/demos/blockfactory/block_factory_expansion.js
@@ -42,7 +42,6 @@ BlockFactoryExpansion.init = function() {
   BlockFactoryExpansion.exporter = new BlockExporterController(
       'blockLibraryExporter', BlockLibrary.Controller.storage);
 
-  BlockFactoryExpansion.exporter.addChangeListeners();
   // Assign button click handlers for Block Exporter.
   document.getElementById('exporterSubmitButton').addEventListener('click',
       function() {
@@ -116,46 +115,58 @@ BlockFactoryExpansion.init = function() {
        toolbox: toolbox,
        media: '../../media/'});
 
-/**
- * Add tab handlers to allow switching between the Block Factory
- * tab and the Block Exporter tab.
- *
- * @param {string} blockFactoryTabID - ID of element containing Block Factory
- * @param {string} blockExporterTabID - ID of element containing Block Exporter
- */
-  var addTabHandlers =
-      function(blockFactoryTabID, blockExporterTabID) {
-        var blockFactoryTab = goog.dom.getElement(blockFactoryTabID);
-        var blockExporterTab = goog.dom.getElement(blockExporterTabID);
+  /**
+   * Add tab handlers to allow switching between the Block Factory
+   * tab and the Block Exporter tab.
+   *
+   * @param {string} blockFactoryTabID - ID of element containing BlockFactory
+   * @param {string} blockExporterTabID - ID of element containing BlockExporter
+   */
+  var addTabHandlers = function(blockFactoryTabID, blockExporterTabID) {
+    var blockFactoryTab = goog.dom.getElement(blockFactoryTabID);
+    var blockExporterTab = goog.dom.getElement(blockExporterTabID);
 
-        blockFactoryTab.addEventListener('click',
-          function() {
-            goog.dom.classlist.addRemove(blockFactoryTab, 'taboff', 'tabon');
-            goog.dom.classlist.addRemove(blockExporterTab, 'tabon', 'taboff');
+    blockFactoryTab.addEventListener('click',
+      function() {
+        goog.dom.classlist.addRemove(blockFactoryTab, 'taboff', 'tabon');
+        goog.dom.classlist.addRemove(blockExporterTab, 'tabon', 'taboff');
 
-            // Hide container of exporter.
-            BlockFactory.hide('blockLibraryExporter');
+        // Hide container of exporter.
+        BlockFactory.hide('blockLibraryExporter');
 
-            // Resize to render workspaces' toolboxes correctly.
-            window.dispatchEvent(new Event('resize'));
-          });
+        // Resize to render workspaces' toolboxes correctly.
+        window.dispatchEvent(new Event('resize'));
+      });
 
-        blockExporterTab.addEventListener('click',
-          function() {
-            goog.dom.classlist.addRemove(blockFactoryTab, 'tabon', 'taboff');
-            goog.dom.classlist.addRemove(blockExporterTab, 'taboff', 'tabon');
+    blockExporterTab.addEventListener('click',
+      function() {
+        goog.dom.classlist.addRemove(blockFactoryTab, 'tabon', 'taboff');
+        goog.dom.classlist.addRemove(blockExporterTab, 'taboff', 'tabon');
 
-            // Update toolbox to reflect current block library.
-            BlockFactoryExpansion.exporter.updateToolbox();
+        // Update toolbox to reflect current block library.
+        BlockFactoryExpansion.exporter.updateToolbox();
 
-            // Show container of exporter.
-            BlockFactory.show('blockLibraryExporter');
+        // Show container of exporter.
+        BlockFactory.show('blockLibraryExporter');
 
-            // Resize to render workspaces' toolboxes correctly.
-            window.dispatchEvent(new Event('resize'));
-          });
-      };
+        // Resize to render workspaces' toolboxes correctly.
+        window.dispatchEvent(new Event('resize'));
+      });
+  };
   addTabHandlers("blockfactory_tab", "blocklibraryExporter_tab");
+
+  var addChangeListenersToSelectorWorkspace = function() {
+    var selector = BlockFactoryExpansion.exporter.view.selectorWorkspace;
+    selector.addChangeListener(
+      function(event) {
+        BlockFactoryExpansion.exporter.onSelectBlockForExport(event);
+      });
+    selector.addChangeListener(
+      function(event) {
+        BlockFactoryExpansion.exporter.onDeselectBlockForExport(event);
+      });
+  };
+  addChangeListenersToSelectorWorkspace();
 
   // Create the root block.on main workspace.
   if ('BlocklyStorage' in window && window.location.hash.length > 1) {

--- a/demos/blockfactory/block_factory_expansion.js
+++ b/demos/blockfactory/block_factory_expansion.js
@@ -175,21 +175,7 @@ BlockFactoryExpansion.init = function() {
       };
   addTabHandlers("blockfactory_tab", "blocklibraryExporter_tab");
 
-  /**
-   * Add change listeners to the exporter's selector workspace.
-   */
-  var addChangeListenersToSelectorWorkspace = function() {
-    var selector = BlockFactoryExpansion.exporter.view.selectorWorkspace;
-    selector.addChangeListener(
-      function(event) {
-        BlockFactoryExpansion.exporter.onSelectBlockForExport(event);
-      });
-    selector.addChangeListener(
-      function(event) {
-        BlockFactoryExpansion.exporter.onDeselectBlockForExport(event);
-      });
-  };
-  addChangeListenersToSelectorWorkspace();
+  BlockFactoryExpansion.exporter.addChangeListenersToSelectorWorkspace();
 
   // Create the root block.on main workspace.
   if ('BlocklyStorage' in window && window.location.hash.length > 1) {


### PR DESCRIPTION
 In the selector workspace, the user is limited to one block of a given type, ensuring that they don't have multiple copies of the same block definition or generator stub.
- When a block is created on the workspace, disable the block in the selector toolbox.
- When a block is deleted from the workspace, enable the block in the selector toolbox.

Also updates the helper text accordingly by showing what blocks are currently selected.

<img width="1147" alt="screen shot 2016-08-01 at 4 14 34 pm" src="https://cloud.githubusercontent.com/assets/10423718/17311844/23650e4e-5803-11e6-82d2-486f40c10d83.png">

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quachtina96/blockly/14)

<!-- Reviewable:end -->
