### PR TITLE
Block Exporter #5: Enable/Disable with Clear Selected, Prefer JSON

### DIFF
--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -195,12 +195,6 @@ BlockExporterController.prototype.onDeselectBlockForExport_ = function(event) {
  * Deselects all blocks on tfhe selector workspace by deleting them.
  */
 BlockExporterController.prototype.clearSelectedBlocks = function() {
-  var blocksToClear = this.view.getSelectedBlocks();
-  for (var i = 0; i < blocksToClear.length; i++) {
-    // Fire a delete event for each block cleared from workspace to enable the
-    // block in selector toolbox.
-    Blockly.Events.fire(new Blockly.Events.Delete(blocksToClear[i]));
-  }
   // Clear selector workspace.
   this.view.clearSelectorWorkspace();
 };

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -108,3 +108,18 @@ BlockExporterController.prototype.updateToolbox = function(opt_toolboxXml) {
   // Render the toolbox in the selector workspace.
   this.view.renderToolbox(updatedToolbox);
 };
+
+/**
+ * Tied to the 'Clear Selected Blocks' button in the Block Exporter.
+ * Deselects all blocks on the selector workspace by deleting them and updating
+ * text accordingly.
+ */
+BlockExporterController.prototype.clearSelectedBlocks = function() {
+  // Clear selector workspace.
+  this.view.clearSelectorWorkspace();
+  // Edit helper text
+  this.view.updateHelperText('No blocks selected. Drag block into workspace' +
+      ' to select.');
+  // TODO(quacht): After mergeing enable/disable blocks, throw delete events
+  // for each block.
+};

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -37,7 +37,7 @@ BlockExporterController = function(blockLibStorage) {
  * @return {!Array.<string>} Types of blocks in workspace.
  */
 BlockExporterController.prototype.getSelectedBlockTypes_ = function() {
-  var selectedBlocks = this.view.selectorWorkspace.getAllBlocks();
+  var selectedBlocks = this.view.getSelectedBlocks();
   var blockTypes = [];
   for (var i = 0; i < selectedBlocks.length; i++) {
     blockTypes.push(selectedBlocks[i].type);
@@ -94,7 +94,8 @@ BlockExporterController.prototype.exportBlocks = function() {
 };
 
 /**
- * Update the Exporter's toolbox.
+ * Update the Exporter's toolbox with either the given toolbox xml or toolbox
+ * xml generated from blocks stored in block library.
  *
  * @param {Element} opt_toolboxXml - Xml to define toolbox of the selector
  *    workspace.
@@ -102,6 +103,8 @@ BlockExporterController.prototype.exportBlocks = function() {
 BlockExporterController.prototype.updateToolbox = function(opt_toolboxXml) {
   var updatedToolbox = opt_toolboxXml ||
       this.tools.generateToolboxFromLibrary(this.blockLibStorage);
+  // Update the view's toolbox.
   this.view.setToolbox(updatedToolbox);
+  // Render the toolbox in the selector workspace.
   this.view.renderToolbox(updatedToolbox);
 };

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -192,8 +192,7 @@ BlockExporterController.prototype.onDeselectBlockForExport_ = function(event) {
 
 /**
  * Tied to the 'Clear Selected Blocks' button in the Block Exporter.
- * Deselects all blocks on the selector workspace by deleting them and updating
- * text accordingly.
+ * Deselects all blocks on tfhe selector workspace by deleting them.
  */
 BlockExporterController.prototype.clearSelectedBlocks = function() {
   // Clear selector workspace.

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -192,8 +192,7 @@ BlockExporterController.prototype.onDeselectBlockForExport_ = function(event) {
 
 /**
  * Tied to the 'Clear Selected Blocks' button in the Block Exporter.
- * Deselects all blocks on the selector workspace by deleting them and updating
- * text accordingly.
+ * Deselects all blocks on tfhe selector workspace by deleting them.
  */
 BlockExporterController.prototype.clearSelectedBlocks = function() {
   var blocksToClear = this.view.getSelectedBlocks();

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -198,6 +198,4 @@ BlockExporterController.prototype.onDeselectBlockForExport_ = function(event) {
 BlockExporterController.prototype.clearSelectedBlocks = function() {
   // Clear selector workspace.
   this.view.clearSelectorWorkspace();
-  // TODO(quacht): After merging enable/disable blocks, throw delete events
-  // for each block.
 };

--- a/demos/blockfactory/block_exporter_view.js
+++ b/demos/blockfactory/block_exporter_view.js
@@ -76,5 +76,20 @@ BlockExporterView.prototype.updateHelperText = function(newText, opt_append) {
   }
 };
 
+/**
+ * Clears selector workspace.
+ */
+BlockExporterView.prototype.clearSelectorWorkspace = function() {
+  this.selectorWorkspace.clear();
+};
+
+/**
+ * Returns array of selected blocks.
+ *
+ * @return {Array.<Blockly.Block>} Array of all blocks in selector workspace.
+ */
+BlockExporterView.prototype.getSelectedBlocks = function() {
+  return this.selectorWorkspace.getAllBlocks();
+};
 
 

--- a/demos/blockfactory/block_factory_expansion.js
+++ b/demos/blockfactory/block_factory_expansion.js
@@ -134,6 +134,11 @@ BlockFactoryExpansion.init = function() {
         BlockFactoryExpansion.exporter.exportBlocks();
       });
 
+  document.getElementById('clearSelectedButton').addEventListener('click',
+      function() {
+        BlockFactoryExpansion.exporter.clearSelectedBlocks();
+      });
+
   /**
    * Add tab handlers to allow switching between the Block Factory
    * tab and the Block Exporter tab.

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -83,13 +83,13 @@
             </span>
             </td>
             <td id="blockLibraryControls">
-            <button id="saveToBlockLibraryButton" title="Save block xml to a local file.">
+            <button id="saveToBlockLibraryButton" title="Save block to library.">
               <span>Save to Block Library</span>
             </button>
             <button id="removeBlockFromLibraryButton" title="Remove block from library.">
               <span>Remove Current Block from Library</span>
             </button>
-            <button id="clearBlockLibraryButton" title="Clear Block Library below.">
+            <button id="clearBlockLibraryButton" title="Clear block library .">
               <span>Clear Block Library</span>
             </button>
             </td>

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -46,8 +46,8 @@
         <input type="checkbox" id="blockDefCheck"><br>
               Language code:
                 <select id="exportFormat">
-                  <option value="JavaScript">JavaScript</option>
                   <option value="JSON">JSON</option>
+                  <option value="JavaScript">JavaScript</option>
                 </select><br>
           Block Definition(s) File Name:<br>
           <input type="text" id="blockDef_filename"><br>
@@ -146,8 +146,8 @@
             <td height="5%">
               <h3>Language code:
                 <select id="format">
-                  <option value="JavaScript">JavaScript</option>
                   <option value="JSON">JSON</option>
+                  <option value="JavaScript">JavaScript</option>
                   <option value="Manual">Manual edit&hellip;</option>
                 </select>
                 <button class ="downloadButton" id="downloadBlocks"

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -66,6 +66,7 @@
           <br>
       </form>
         <button id="exporterSubmitButton"> Export </button>
+        <button id="clearSelectedButton"> Clear Selected Blocks </button>
     </div>
   </div>
 


### PR DESCRIPTION
- Fire Blockly delete events when clearing selected blocks to enable them in the toolbox.
- Make JSON the default setting for block definitions.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quachtina96/blockly/16)

<!-- Reviewable:end -->
