### PR TITLE
Block Exporter #4: Exporter Div Formatting

### DIFF
--- a/demos/blockfactory/block_exporter_tools.js
+++ b/demos/blockfactory/block_exporter_tools.js
@@ -21,10 +21,10 @@ goog.require('goog.dom.xml');
 BlockExporterTools = function() {
   // Create container for hidden workspace.
   this.container = goog.dom.createDom('div', {
-    'id': 'blockExporterTools_hiddenWorkspace',
-    'display': 'none'
+    'id': 'blockExporterTools_hiddenWorkspace'
   }, ''); // Empty quotes for empty div.
-
+  // Hide hidden workspace.
+  this.container.style.display = 'none';
   goog.dom.appendChild(document.body, this.container);
   /**
    * Hidden workspace for the Block Exporter that holds pieces that make

--- a/demos/blockfactory/block_factory_expansion.js
+++ b/demos/blockfactory/block_factory_expansion.js
@@ -158,7 +158,6 @@ BlockFactoryExpansion.init = function() {
 
             // Hide container of exporter.
             BlockFactory.hide('blockLibraryExporter');
-            BlockFactory.hide('gap');
 
             // Resize to render workspaces' toolboxes correctly.
             window.dispatchEvent(new Event('resize'));
@@ -174,7 +173,6 @@ BlockFactoryExpansion.init = function() {
 
             // Show container of exporter.
             BlockFactory.show('blockLibraryExporter');
-            BlockFactory.show('gap');
 
             // Resize to render workspaces' toolboxes correctly.
             window.dispatchEvent(new Event('resize'));

--- a/demos/blockfactory/block_factory_expansion.js
+++ b/demos/blockfactory/block_factory_expansion.js
@@ -158,6 +158,7 @@ BlockFactoryExpansion.init = function() {
 
             // Hide container of exporter.
             BlockFactory.hide('blockLibraryExporter');
+            BlockFactory.hide('gap');
 
             // Resize to render workspaces' toolboxes correctly.
             window.dispatchEvent(new Event('resize'));
@@ -173,6 +174,7 @@ BlockFactoryExpansion.init = function() {
 
             // Show container of exporter.
             BlockFactory.show('blockLibraryExporter');
+            BlockFactory.show('gap');
 
             // Resize to render workspaces' toolboxes correctly.
             window.dispatchEvent(new Event('resize'));

--- a/demos/blockfactory/factory.css
+++ b/demos/blockfactory/factory.css
@@ -165,7 +165,8 @@ button, .buttonStyle {
 }
 
 #gap {
-  height: 20px;
+  height: 100px;
+  clear: both;
 }
 
 /* Tabs */

--- a/demos/blockfactory/factory.css
+++ b/demos/blockfactory/factory.css
@@ -164,6 +164,10 @@ button, .buttonStyle {
  display: none;
 }
 
+#gap {
+  height: 20px;
+}
+
 /* Tabs */
 
 .tab {

--- a/demos/blockfactory/factory.css
+++ b/demos/blockfactory/factory.css
@@ -144,7 +144,8 @@ button, .buttonStyle {
 #blockLibraryExporter {
   clear: both;
   display: none;
-  height: 90%;
+  height: 100%;
+  margin-bottom: 20px;
 }
 
 #exportSelector {

--- a/demos/blockfactory/factory.css
+++ b/demos/blockfactory/factory.css
@@ -164,11 +164,6 @@ button, .buttonStyle {
  display: none;
 }
 
-#gap {
-  height: 100px;
-  clear: both;
-}
-
 /* Tabs */
 
 .tab {

--- a/demos/blockfactory/factory.css
+++ b/demos/blockfactory/factory.css
@@ -145,7 +145,6 @@ button, .buttonStyle {
   clear: both;
   display: none;
   height: 100%;
-  margin-bottom: 20px;
 }
 
 #exportSelector {

--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -887,7 +887,7 @@ BlockFactory.hide = function(elementID) {
  * @param {string} elementID - ID of element to hide.
  */
 BlockFactory.show = function(elementID) {
-  document.getElementById(elementID).style.display = 'inline';
+  document.getElementById(elementID).style.display = 'block';
 };
 
 /**

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -69,7 +69,6 @@
         <button id="clearSelectedButton"> Clear Selected Blocks </button>
     </div>
   </div>
-  <div id="gap"></div>
   <table id="blockFactoryContent">
     <tr>
       <td width="50%" height="5%">

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -69,7 +69,7 @@
         <button id="clearSelectedButton"> Clear Selected Blocks </button>
     </div>
   </div>
-
+  <div id="gap"></div>
   <table id="blockFactoryContent">
     <tr>
       <td width="50%" height="5%">


### PR DESCRIPTION
Before: Block Library peeked out from below while on the Block Exporter Tab
<img width="1438" alt="screen shot 2016-08-02 at 4 23 01 pm" src="https://cloud.githubusercontent.com/assets/10423718/17348755/6fa04240-58cd-11e6-8dd2-686bd8e282c4.png">

After:
<img width="1440" alt="screen shot 2016-08-02 at 4 24 54 pm" src="https://cloud.githubusercontent.com/assets/10423718/17348788/b3b637b4-58cd-11e6-8e0b-38dbfaf580da.png">
### block_exporter_tools.js
- properly hides the hidden workspace --before, you could see the edge of it at the bottom on the block factory tab.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quachtina96/blockly/17)

<!-- Reviewable:end -->
