### PR TITLE
Block Library: Select Dummy Option & Confirm Library Clear

### DIFF
--- a/demos/blockfactory/block_library_controller.js
+++ b/demos/blockfactory/block_library_controller.js
@@ -92,12 +92,9 @@ BlockLibraryController.prototype.clearBlockLibrary = function() {
     this.storage.saveToLocalStorage();
     // Update dropdown.
     BlockLibraryView.clearOptions('blockLibraryDropdown');
-<<<<<<< HEAD
     // Add a default, blank option to dropdown for when no block from library is
     // selected.
     BlockLibraryView.addDefaultOption('blockLibraryDropdown');
-=======
->>>>>>> 4606074... moved call to addOption from lib controller to view
   }
 };
 

--- a/demos/blockfactory/block_library_controller.js
+++ b/demos/blockfactory/block_library_controller.js
@@ -80,15 +80,24 @@ BlockLibraryController.prototype.getSelectedBlockType =
     };
 
 /**
- * Clears the block library in local storage and updates the dropdown.
+ * Confirms with user before clearing the block library in local storage and
+ * updating the dropdown.
  */
 BlockLibraryController.prototype.clearBlockLibrary = function() {
-  var check = prompt(
-      'Are you sure you want to clear your Block Library? ("yes" or "no")');
-  if (check == "yes") {
+  var check = confirm(
+      'Click OK to clear your block library.');
+  if (check) {
+    // Clear Block Library Storage.
     this.storage.clear();
     this.storage.saveToLocalStorage();
+    // Update dropdown.
     BlockLibraryView.clearOptions('blockLibraryDropdown');
+<<<<<<< HEAD
+    // Add a default, blank option to dropdown for when no block from library is
+    // selected.
+    BlockLibraryView.addDefaultOption('blockLibraryDropdown');
+=======
+>>>>>>> 4606074... moved call to addOption from lib controller to view
   }
 };
 
@@ -105,7 +114,7 @@ BlockLibraryController.prototype.saveToBlockLibrary = function() {
     this.storage.addBlock(blockType, xmlElement);
     this.storage.saveToLocalStorage();
     BlockLibraryView.addOption(
-        blockType, blockType, 'blockLibraryDropdown', true);
+        blockType, blockType, 'blockLibraryDropdown', true, true);
   }
 };
 
@@ -129,11 +138,17 @@ BlockLibraryController.prototype.populateBlockLibrary = function() {
          'you can reopen it the next time you visit Block Factory!');
   }
   BlockLibraryView.clearOptions('blockLibraryDropdown');
+  // Add a default, blank option to dropdown for when no block from library is
+  // selected.
+  BlockLibraryView.addDefaultOption('blockLibraryDropdown');
+  // Add option for each saved block.
   var blockLibrary = this.storage.blocks;
   for (var block in blockLibrary) {
     // Make sure the block wasn't deleted.
     if (blockLibrary[block] != null) {
-      BlockLibraryView.addOption(block, block, 'blockLibraryDropdown', false);
+      BlockLibraryView.addOption(
+          block, block, 'blockLibraryDropdown', false, true);
     }
   }
 };
+

--- a/demos/blockfactory/block_library_view.js
+++ b/demos/blockfactory/block_library_view.js
@@ -66,17 +66,6 @@ BlockLibraryView.addDefaultOption = function(dropdownID) {
 };
 
 /**
- * Adds a default, blank option to dropdown for when no block from library is
- * selected.
- *
- * @param {string} dropdownID - ID of HTML select element
- */
-BlockLibraryView.addDefaultOption = function(dropdownID) {
-  BlockLibraryView.addOption(
-      'BLOCK_LIBRARY_DEFAULT_BLANK', '', dropdownID, true, false);
-};
-
-/**
  * Returns block type of selected block.
  *
  * @param {Element} dropdown - HTML select element.

--- a/demos/blockfactory/block_library_view.js
+++ b/demos/blockfactory/block_library_view.js
@@ -17,13 +17,15 @@ goog.provide('BlockLibraryView');
  * @param {string} dropdownID - ID for HTML select element.
  * @param {boolean} selected - Whether or not the option should be selected on the
  *     dropdown.
+ * @param {boolean} enabled - Whether or not the option should be enabled.
  */
-BlockLibraryView.addOption = function(optionName, optionText, dropdownID, selected) {
+BlockLibraryView.addOption = function(optionName, optionText, dropdownID, selected, enabled) {
   var dropdown = document.getElementById(dropdownID);
   var option = document.createElement('option');
   option.text = optionText;
   option.value = optionName;
   option.selected = selected;
+  option.disabled = !enabled;
   dropdown.add(option);
 };
 
@@ -50,6 +52,20 @@ BlockLibraryView.clearOptions = function(dropdownID) {
   while (dropdown.length > 0) {
     dropdown.remove(dropdown.length - 1);
   }
+  // Default blank option for when no block from library is selected.
+  BlockLibraryView.addOption(
+      'BLOCK_LIBRARY_DEFAULT_BLANK', '', 'blockLibraryDropdown', true, false);
+};
+
+/**
+ * Adds a default, blank option to dropdown for when no block from library is
+ * selected.
+ *
+ * @param {string} dropdownID - ID of HTML select element
+ */
+BlockLibraryView.addDefaultOption = function(dropdownID) {
+  BlockLibraryView.addOption(
+      'BLOCK_LIBRARY_DEFAULT_BLANK', '', dropdownID, true, false);
 };
 
 /**

--- a/demos/blockfactory/block_library_view.js
+++ b/demos/blockfactory/block_library_view.js
@@ -52,9 +52,17 @@ BlockLibraryView.clearOptions = function(dropdownID) {
   while (dropdown.length > 0) {
     dropdown.remove(dropdown.length - 1);
   }
-  // Default blank option for when no block from library is selected.
+};
+
+/**
+ * Adds a default, blank option to dropdown for when no block from library is
+ * selected.
+ *
+ * @param {string} dropdownID - ID of HTML select element
+ */
+BlockLibraryView.addDefaultOption = function(dropdownID) {
   BlockLibraryView.addOption(
-      'BLOCK_LIBRARY_DEFAULT_BLANK', '', 'blockLibraryDropdown', true, false);
+      'BLOCK_LIBRARY_DEFAULT_BLANK', '', dropdownID, true, false);
 };
 
 /**


### PR DESCRIPTION
## Select Dummy Option

When the page loads, the user hasn't selected a block from the library.
<img width="1421" alt="screen shot 2016-08-02 at 5 43 58 pm" src="https://cloud.githubusercontent.com/assets/10423718/17350235/a853e004-58d9-11e6-8c61-7858ca05a8c4.png">
<img width="903" alt="screen shot 2016-08-02 at 5 52 18 pm" src="https://cloud.githubusercontent.com/assets/10423718/17350262/f0951036-58d9-11e6-99a6-ec2a096e5b27.png">

When user deletes a block from library, selected option is blank and the blocks on the workspace stay the same.
<img width="1418" alt="screen shot 2016-08-02 at 5 44 19 pm" src="https://cloud.githubusercontent.com/assets/10423718/17350233/a48faa66-58d9-11e6-8c89-cdce288710f8.png">
### block_library_view
- addOption now can create disabled options
## Confirm Library Clear
### block_library_controller

Use confirm rather than alert to make sure the user wants to clear the block library.
<img width="500" alt="screen shot 2016-08-02 at 5 54 29 pm" src="https://cloud.githubusercontent.com/assets/10423718/17350290/31e1e2bc-58da-11e6-9bc6-3ce67476bae9.png">

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quachtina96/blockly/18)

<!-- Reviewable:end -->
