### PR TITLE
Block Exporter #5: Disable Selected Blocks on Tab Switch

### DIFF
--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -29,8 +29,6 @@ BlockExporterController = function(blockLibStorage) {
   this.view = new BlockExporterView(
       //Xml representation of the toolbox
       this.tools.generateToolboxFromLibrary(this.blockLibStorage));
-  // Selected blocks are disabled in the selector toolbox.
-  this.disabledBlocks = new Set();
 };
 
 /**
@@ -117,7 +115,6 @@ BlockExporterController.prototype.updateToolbox = function(opt_toolboxXml) {
     this.setBlockEnabled(selectedBlocks[i], false);
   }
 };
-
 
 /**
  * Enable or Disable block in selector workspace's toolbox.

--- a/demos/blockfactory/block_exporter_controller.js
+++ b/demos/blockfactory/block_exporter_controller.js
@@ -29,6 +29,8 @@ BlockExporterController = function(blockLibStorage) {
   this.view = new BlockExporterView(
       //Xml representation of the toolbox
       this.tools.generateToolboxFromLibrary(this.blockLibStorage));
+  // Selected blocks are disabled in the selector toolbox.
+  this.disabledBlocks = new Set();
 };
 
 /**
@@ -102,13 +104,20 @@ BlockExporterController.prototype.exportBlocks = function() {
  *    workspace.
  */
 BlockExporterController.prototype.updateToolbox = function(opt_toolboxXml) {
+  // Use given xml or xml generated from updated block library.
   var updatedToolbox = opt_toolboxXml ||
       this.tools.generateToolboxFromLibrary(this.blockLibStorage);
   // Update the view's toolbox.
   this.view.setToolbox(updatedToolbox);
   // Render the toolbox in the selector workspace.
   this.view.renderToolbox(updatedToolbox);
+  // Disable any selected blocks.
+  var selectedBlocks = this.getSelectedBlockTypes_();
+  for (var i = 0; i < selectedBlocks.length; i++) {
+    this.setBlockEnabled(selectedBlocks[i], false);
+  }
 };
+
 
 /**
  * Enable or Disable block in selector workspace's toolbox.
@@ -118,6 +127,7 @@ BlockExporterController.prototype.updateToolbox = function(opt_toolboxXml) {
  */
 BlockExporterController.prototype.setBlockEnabled =
     function(blockType, enable) {
+  // Get toolbox xml, category, and block elements.
   var toolboxXml = this.view.toolbox;
   var category = goog.dom.xml.selectSingleNode(toolboxXml,
       '//category[@name="' + blockType + '"]');


### PR DESCRIPTION
- fixed bug where switching tabs would update the toolbox with all enabled blocks--despite selected blocks still being on the workspace. 
- edited exporter controller's updateToolbox() function (which is called upon tab switch to account for any changes to the block library) to disable all selected blocks.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quachtina96/blockly/19)

<!-- Reviewable:end -->
