### PR TITLE
Block Library: Replace Saved Block

### DIFF
--- a/demos/blockfactory/block_library_controller.js
+++ b/demos/blockfactory/block_library_controller.js
@@ -113,10 +113,12 @@ BlockLibraryController.prototype.saveToBlockLibrary = function() {
       return;
     }
   }
+
   // Save block.
   var xmlElement = Blockly.Xml.workspaceToDom(BlockFactory.mainWorkspace);
   this.storage.addBlock(blockType, xmlElement);
   this.storage.saveToLocalStorage();
+
   // Do not add another option to dropdown if replacing.
   if (replace) {
     return;

--- a/demos/blockfactory/block_library_controller.js
+++ b/demos/blockfactory/block_library_controller.js
@@ -103,16 +103,26 @@ BlockLibraryController.prototype.clearBlockLibrary = function() {
  */
 BlockLibraryController.prototype.saveToBlockLibrary = function() {
   var blockType = this.getCurrentBlockType();
+  // If block under that name already exists, confirm that user wants to replace
+  // saved block.
   if (this.isInBlockLibrary(blockType)) {
-    alert('You already have a block called ' + blockType + ' in your library.' +
-      ' Please rename your block or delete the old one.');
-  } else {
-    var xmlElement = Blockly.Xml.workspaceToDom(BlockFactory.mainWorkspace);
-    this.storage.addBlock(blockType, xmlElement);
-    this.storage.saveToLocalStorage();
-    BlockLibraryView.addOption(
-        blockType, blockType, 'blockLibraryDropdown', true, true);
+    var replace = confirm('You already have a block called ' + blockType +
+      ' in your library. Click OK to replace.');
+    if (!replace) {
+      // Do not save if user doesn't want to replace the saved block.
+      return;
+    }
   }
+  // Save block.
+  var xmlElement = Blockly.Xml.workspaceToDom(BlockFactory.mainWorkspace);
+  this.storage.addBlock(blockType, xmlElement);
+  this.storage.saveToLocalStorage();
+  // Do not add another option to dropdown if replacing.
+  if (replace) {
+    return;
+  }
+  BlockLibraryView.addOption(
+      blockType, blockType, 'blockLibraryDropdown', true, true);
 };
 
 /**


### PR DESCRIPTION
If the user tries to save a block under the same name as one already existing in the library, the user can replace existing saved block with a newer version. The user no longer has to delete before saving.

<img width="1005" alt="replace save" src="https://cloud.githubusercontent.com/assets/10423718/17386962/1848443e-59a4-11e6-9410-141d47ec5b5f.png">

Edited the saveToBlockLibrary function in BlockLibraryController to handle the case that the user wants to replace.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quachtina96/blockly/21)

<!-- Reviewable:end -->
