### PR TITLE
Block Factory Expansion: Button Format, Select Default Option on Create New Block

### DIFF
--- a/demos/blockfactory/app_controller.js
+++ b/demos/blockfactory/app_controller.js
@@ -96,18 +96,18 @@ AppController.prototype.onFactoryTab =
  */
 AppController.prototype.onExporterTab =
     function(blockFactoryTab, blockExporterTab) {
-    // Turn exporter tab on and factory tab off.
-    goog.dom.classlist.addRemove(blockFactoryTab, 'tabon', 'taboff');
-    goog.dom.classlist.addRemove(blockExporterTab, 'taboff', 'tabon');
+  // Turn exporter tab on and factory tab off.
+  goog.dom.classlist.addRemove(blockFactoryTab, 'tabon', 'taboff');
+  goog.dom.classlist.addRemove(blockExporterTab, 'taboff', 'tabon');
 
-    // Update toolbox to reflect current block library.
-    this.exporter.updateToolbox();
+  // Update toolbox to reflect current block library.
+  this.exporter.updateToolbox();
 
-    // Show container of exporter.
-    BlockFactory.show('blockLibraryExporter');
+  // Show container of exporter.
+  BlockFactory.show('blockLibraryExporter');
 
-    // Resize to render workspaces' toolboxes correctly.
-    window.dispatchEvent(new Event('resize'));
+  // Resize to render workspaces' toolboxes correctly.
+  window.dispatchEvent(new Event('resize'));
 };
 
 /**

--- a/demos/blockfactory/app_controller.js
+++ b/demos/blockfactory/app_controller.js
@@ -187,6 +187,7 @@ AppController.prototype.assignFactoryClickHandlers = function() {
     .addEventListener('click', function() {
         BlockFactory.mainWorkspace.clear();
         BlockFactory.showStarterBlock();
+        BlockLibraryView.selectDefaultOption('blockLibraryDropdown');
     });
 };
 

--- a/demos/blockfactory/block_exporter_tools.js
+++ b/demos/blockfactory/block_exporter_tools.js
@@ -77,35 +77,35 @@ BlockExporterTools.prototype.getDefinedBlock_ = function(blockType) {
  */
 BlockExporterTools.prototype.getBlockDefs =
     function(blockXmlMap, definitionFormat) {
-      var blockCode = [];
-      for (var blockType in blockXmlMap) {
-        var xml = blockXmlMap[blockType];
-        if (xml) {
-          // Render and get block from hidden workspace.
-          var rootBlock = this.getRootBlockFromXml_(xml);
-          if (rootBlock) {
-            // Generate the block's definition.
-            var code = BlockFactory.getBlockDefinition(blockType, rootBlock,
-                definitionFormat, this.hiddenWorkspace);
-            // Add block's definition to the definitions to return.
-          } else {
-            // Append warning comment and write to console.
-            var code = '// No block definition generated for ' + blockType +
-              '. Could not find root block in xml stored for this block.';
-            console.log('No block definition generated for ' + blockType +
-              '. Could not find root block in xml stored for this block.');
-          }
-        } else {
-          // Append warning comment and write to console.
-          var code = '// No block definition generated for ' + blockType +
-            '. Block was not found in Block Library Storage.';
-          console.log('No block definition generated for ' + blockType +
-            '. Block was not found in Block Library Storage.');
-        }
-        blockCode.push(code);
+  var blockCode = [];
+  for (var blockType in blockXmlMap) {
+    var xml = blockXmlMap[blockType];
+    if (xml) {
+      // Render and get block from hidden workspace.
+      var rootBlock = this.getRootBlockFromXml_(xml);
+      if (rootBlock) {
+        // Generate the block's definition.
+        var code = BlockFactory.getBlockDefinition(blockType, rootBlock,
+            definitionFormat, this.hiddenWorkspace);
+        // Add block's definition to the definitions to return.
+      } else {
+        // Append warning comment and write to console.
+        var code = '// No block definition generated for ' + blockType +
+          '. Could not find root block in xml stored for this block.';
+        console.log('No block definition generated for ' + blockType +
+          '. Could not find root block in xml stored for this block.');
       }
-      return blockCode.join("\n\n");
-    };
+    } else {
+      // Append warning comment and write to console.
+      var code = '// No block definition generated for ' + blockType +
+        '. Block was not found in Block Library Storage.';
+      console.log('No block definition generated for ' + blockType +
+        '. Block was not found in Block Library Storage.');
+    }
+    blockCode.push(code);
+  }
+  return blockCode.join("\n\n");
+};
 
 /**
  * Return the generator code of each block type in an array in a given language.
@@ -118,30 +118,30 @@ BlockExporterTools.prototype.getBlockDefs =
  */
 BlockExporterTools.prototype.getGeneratorCode =
     function(blockXmlMap, generatorLanguage) {
-      var multiblockCode = [];
-      // Define the custom blocks in order to be able to create instances of
-      // them in the exporter workspace.
-      this.addBlockDefinitions_(blockXmlMap);
+  var multiblockCode = [];
+  // Define the custom blocks in order to be able to create instances of
+  // them in the exporter workspace.
+  this.addBlockDefinitions_(blockXmlMap);
 
-      for (var blockType in blockXmlMap) {
-        var xml = blockXmlMap[blockType];
-        if (xml) {
-          // Render the preview block in the hidden workspace.
-          var tempBlock = this.getDefinedBlock_(blockType);
-          // Get generator stub for the given block and add to  generator code.
-          var blockGenCode =
-              BlockFactory.getGeneratorStub(tempBlock, generatorLanguage);
-        } else {
-          // Append warning comment and write to console.
-          var blockGenCode = '// No generator stub generated for ' + blockType +
-            '. Block was not found in Block Library Storage.';
-          console.log('No block generator stub generated for ' + blockType +
-            '. Block was not found in Block Library Storage.');
-        }
-        multiblockCode.push(blockGenCode);
-      }
-      return multiblockCode.join("\n\n");
-    };
+  for (var blockType in blockXmlMap) {
+    var xml = blockXmlMap[blockType];
+    if (xml) {
+      // Render the preview block in the hidden workspace.
+      var tempBlock = this.getDefinedBlock_(blockType);
+      // Get generator stub for the given block and add to  generator code.
+      var blockGenCode =
+          BlockFactory.getGeneratorStub(tempBlock, generatorLanguage);
+    } else {
+      // Append warning comment and write to console.
+      var blockGenCode = '// No generator stub generated for ' + blockType +
+        '. Block was not found in Block Library Storage.';
+      console.log('No block generator stub generated for ' + blockType +
+        '. Block was not found in Block Library Storage.');
+    }
+    multiblockCode.push(blockGenCode);
+  }
+  return multiblockCode.join("\n\n");
+};
 
 /**
  * Evaluates block definition code of each block in given object mapping
@@ -152,9 +152,9 @@ BlockExporterTools.prototype.getGeneratorCode =
  * @param {!Object} blockXmlMap - Map of block type to xml.
  */
 BlockExporterTools.prototype.addBlockDefinitions_ = function(blockXmlMap) {
-      var blockDefs = this.getBlockDefs(blockXmlMap, 'JavaScript');
-      eval(blockDefs);
-    };
+  var blockDefs = this.getBlockDefs(blockXmlMap, 'JavaScript');
+  eval(blockDefs);
+};
 
 /**
  * Pulls information about all blocks in the block library to generate xml
@@ -164,40 +164,40 @@ BlockExporterTools.prototype.addBlockDefinitions_ = function(blockXmlMap) {
  */
 BlockExporterTools.prototype.generateToolboxFromLibrary
     = function(blockLibStorage) {
-      // Create DOM for XML.
-      var xmlDom = goog.dom.createDom('xml', {
-        'id' : 'blockExporterTools_toolbox',
-        'style' : 'display:none'
-      });
+  // Create DOM for XML.
+  var xmlDom = goog.dom.createDom('xml', {
+    'id' : 'blockExporterTools_toolbox',
+    'style' : 'display:none'
+  });
 
-      var allBlockTypes = blockLibStorage.getBlockTypes();
-      // Object mapping block type to XML.
-      var blockXmlMap = blockLibStorage.getBlockXmlMap(allBlockTypes);
+  var allBlockTypes = blockLibStorage.getBlockTypes();
+  // Object mapping block type to XML.
+  var blockXmlMap = blockLibStorage.getBlockXmlMap(allBlockTypes);
 
-      // Define the custom blocks in order to be able to create instances of
-      // them in the exporter workspace.
-      this.addBlockDefinitions_(blockXmlMap);
+  // Define the custom blocks in order to be able to create instances of
+  // them in the exporter workspace.
+  this.addBlockDefinitions_(blockXmlMap);
 
-      for (var blockType in blockXmlMap) {
-        // Create category DOM element.
-        var categoryElement = goog.dom.createDom('category');
-        categoryElement.setAttribute('name',blockType);
+  for (var blockType in blockXmlMap) {
+    // Create category DOM element.
+    var categoryElement = goog.dom.createDom('category');
+    categoryElement.setAttribute('name',blockType);
 
-        // Get block.
-        var block = this.getDefinedBlock_(blockType);
+    // Get block.
+    var block = this.getDefinedBlock_(blockType);
 
-        // Get preview block XML.
-        var blockChild = Blockly.Xml.blockToDom(block);
-        blockChild.removeAttribute('id');
+    // Get preview block XML.
+    var blockChild = Blockly.Xml.blockToDom(block);
+    blockChild.removeAttribute('id');
 
-        // Add block to category and category to XML.
-        categoryElement.appendChild(blockChild);
-        xmlDom.appendChild(categoryElement);
-      }
+    // Add block to category and category to XML.
+    categoryElement.appendChild(blockChild);
+    xmlDom.appendChild(categoryElement);
+  }
 
-      // If there are no blocks in library, append dummy category.
-      var categoryElement = goog.dom.createDom('category');
-      categoryElement.setAttribute('name','Next Saved Block');
-      xmlDom.appendChild(categoryElement);
-      return xmlDom;
-    };
+  // If there are no blocks in library, append dummy category.
+  var categoryElement = goog.dom.createDom('category');
+  categoryElement.setAttribute('name','Next Saved Block');
+  xmlDom.appendChild(categoryElement);
+  return xmlDom;
+};

--- a/demos/blockfactory/block_exporter_view.js
+++ b/demos/blockfactory/block_exporter_view.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Javascript for the Block Exporter View class. Takes care of
- * generating the workspace through which users can select blocks to export.
+ * generating the selector workspace through which users select blocks to
+ * export.
  *
  * @author quachtina96 (Tina Quach)
  */

--- a/demos/blockfactory/block_library_controller.js
+++ b/demos/blockfactory/block_library_controller.js
@@ -24,8 +24,6 @@ goog.require('BlockFactory');
  *
  * @param {string} blockLibraryName - Desired name of Block Library, also used
  *    to create the key for where it's stored in local storage.
- * @param {blockLibrary} blockLibraryName - Desired name of Block Library, also
- *    used to create the key for where it's stored in local storage.
  */
 BlockLibraryController = function(blockLibraryName) {
   this.name = blockLibraryName;
@@ -67,7 +65,7 @@ BlockLibraryController.prototype.openBlock = function(blockType) {
    var xml = this.storage.getBlockXml(blockType);
    BlockFactory.mainWorkspace.clear();
    Blockly.Xml.domToWorkspace(xml, BlockFactory.mainWorkspace);
- };
+};
 
 /**
  * Returns type of block selected from library.
@@ -77,8 +75,8 @@ BlockLibraryController.prototype.openBlock = function(blockType) {
  */
 BlockLibraryController.prototype.getSelectedBlockType =
     function(blockLibraryDropdown) {
-      return BlockLibraryView.getSelected(blockLibraryDropdown);
-    };
+  return BlockLibraryView.getSelected(blockLibraryDropdown);
+};
 
 /**
  * Confirms with user before clearing the block library in local storage and

--- a/demos/blockfactory/block_library_controller.js
+++ b/demos/blockfactory/block_library_controller.js
@@ -35,10 +35,11 @@ BlockLibraryController = function(blockLibraryName) {
 
 /**
  * Returns the block type of the block the user is building.
+ * @private
  *
  * @return {string} The current block's type.
  */
-BlockLibraryController.prototype.getCurrentBlockType = function() {
+BlockLibraryController.prototype.getCurrentBlockType_ = function() {
   var rootBlock = BlockFactory.getRootBlock(BlockFactory.mainWorkspace);
   var blockType = rootBlock.getFieldValue('NAME').trim().toLowerCase();
   // Replace white space with underscores
@@ -51,7 +52,7 @@ BlockLibraryController.prototype.getCurrentBlockType = function() {
  * @param {string} blockType - Type of block.
  */
 BlockLibraryController.prototype.removeFromBlockLibrary = function() {
-  var blockType = this.getCurrentBlockType();
+  var blockType = this.getCurrentBlockType_();
   this.storage.removeBlock(blockType);
   this.storage.saveToLocalStorage();
   this.populateBlockLibrary();
@@ -102,7 +103,7 @@ BlockLibraryController.prototype.clearBlockLibrary = function() {
  * Saves current block to local storage and updates dropdown.
  */
 BlockLibraryController.prototype.saveToBlockLibrary = function() {
-  var blockType = this.getCurrentBlockType();
+  var blockType = this.getCurrentBlockType_();
   // If block under that name already exists, confirm that user wants to replace
   // saved block.
   if (this.isInBlockLibrary(blockType)) {

--- a/demos/blockfactory/block_library_view.js
+++ b/demos/blockfactory/block_library_view.js
@@ -12,19 +12,22 @@ goog.provide('BlockLibraryView');
 /**
  * Creates a node of a given element type and appends to the node with given id.
  *
- * @param {string} optionName - Value of option.
- * @param {string} optionText - Text in option.
+ * @param {string} optionIdentifier - String used to identify option.
+ * @param {string} optionText - Text to display in the dropdown for the option.
  * @param {string} dropdownID - ID for HTML select element.
  * @param {boolean} selected - Whether or not the option should be selected on
  *    the dropdown.
  * @param {boolean} enabled - Whether or not the option should be enabled.
  */
-BlockLibraryView.addOption =
-    function(optionName, optionText, dropdownID, selected, enabled) {
+BlockLibraryView.addOption
+    = function(optionIdentifier, optionText, dropdownID, selected, enabled) {
   var dropdown = document.getElementById(dropdownID);
   var option = document.createElement('option');
+  // The value attribute of a dropdown's option is not visible in the UI, but is
+  // useful for identifying different options that may have the same text.
+  option.value = optionIdentifier;
+  // The text attribute is what the user sees in the dropdown for the option.
   option.text = optionText;
-  option.value = optionName;
   option.selected = selected;
   option.disabled = !enabled;
   dropdown.add(option);

--- a/demos/blockfactory/block_library_view.js
+++ b/demos/blockfactory/block_library_view.js
@@ -30,6 +30,43 @@ BlockLibraryView.addOption = function(optionName, optionText, dropdownID, select
 };
 
 /**
+ * Adds a default, blank option to dropdown for when no block from library is
+ * selected.
+ *
+ * @param {string} dropdownID - ID of HTML select element
+ */
+BlockLibraryView.addDefaultOption = function(dropdownID) {
+  BlockLibraryView.addOption(
+      'BLOCK_LIBRARY_DEFAULT_BLANK', '', dropdownID, true, false);
+};
+
+/**
+ * Selects the default, blank option in dropdown identified by given ID.
+ *
+ * @param {string} dropdownID - ID of HTML select element
+ */
+BlockLibraryView.selectDefaultOption = function(dropdownID) {
+  var dropdown = document.getElementById(dropdownID);
+  // Deselect currently selected option.
+  var index = dropdown.selectedIndex;
+  dropdown.options[index].selected = false;
+  // Select default option, always the first in the dropdown.
+  var defaultOption = dropdown.options[0];
+  defaultOption.selected = true;
+};
+
+/**
+ * Returns block type of selected block.
+ *
+ * @param {Element} dropdown - HTML select element.
+ * @return {string} Type of block selected.
+ */
+BlockLibraryView.getSelected = function(dropdown) {
+  var index = dropdown.selectedIndex;
+  return dropdown.options[index].value;
+};
+
+/**
  * Removes option currently selected in dropdown from dropdown menu.
  *
  * @param {string} dropdownID - ID of HTML select element within which to find
@@ -54,25 +91,4 @@ BlockLibraryView.clearOptions = function(dropdownID) {
   }
 };
 
-/**
- * Adds a default, blank option to dropdown for when no block from library is
- * selected.
- *
- * @param {string} dropdownID - ID of HTML select element
- */
-BlockLibraryView.addDefaultOption = function(dropdownID) {
-  BlockLibraryView.addOption(
-      'BLOCK_LIBRARY_DEFAULT_BLANK', '', dropdownID, true, false);
-};
-
-/**
- * Returns block type of selected block.
- *
- * @param {Element} dropdown - HTML select element.
- * @return {string} Type of block selected.
- */
-BlockLibraryView.getSelected = function(dropdown) {
-  var index = dropdown.selectedIndex;
-  return dropdown.options[index].value;
-};
 

--- a/demos/blockfactory/block_library_view.js
+++ b/demos/blockfactory/block_library_view.js
@@ -15,11 +15,12 @@ goog.provide('BlockLibraryView');
  * @param {string} optionName - Value of option.
  * @param {string} optionText - Text in option.
  * @param {string} dropdownID - ID for HTML select element.
- * @param {boolean} selected - Whether or not the option should be selected on the
- *     dropdown.
+ * @param {boolean} selected - Whether or not the option should be selected on
+ *    the dropdown.
  * @param {boolean} enabled - Whether or not the option should be enabled.
  */
-BlockLibraryView.addOption = function(optionName, optionText, dropdownID, selected, enabled) {
+BlockLibraryView.addOption =
+    function(optionName, optionText, dropdownID, selected, enabled) {
   var dropdown = document.getElementById(dropdownID);
   var option = document.createElement('option');
   option.text = optionText;

--- a/demos/blockfactory/factory.css
+++ b/demos/blockfactory/factory.css
@@ -78,7 +78,7 @@ button:disabled, .buttonStyle:disabled {
 }
 
 button>*, .buttonStyle>* {
-  opacity: 0.6;
+  opacity: 1;
   vertical-align: text-bottom;
 }
 

--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -887,7 +887,7 @@ BlockFactory.disableEnableLink = function() {
 // Block Factory Expansion View Utils
 
 /**
- * Render starter block (math_foo).
+ * Render starter block (factory_base).
  */
  BlockFactory.showStarterBlock = function() {
     var xml = '<xml><block type="factory_base" deletable="false" ' +

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -199,7 +199,7 @@
       </td>
   </table>
 
-  <xml id="toolbox" style="display: none">
+  <xml id="toolbox">
     <category name="Input">
       <block type="input_value">
         <value name="TYPE">

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -23,8 +23,9 @@
   <link rel="stylesheet" href="../prettify.css">
   <script src="../prettify.js"></script>
   <script>
-    var init = function () {
-      var blocklyDevTools = new AppController();
+    var blocklyDevTools;
+    var init = function() {
+      blocklyDevTools = new AppController();
       blocklyDevTools.init();
     };
     window.addEventListener('load', init);


### PR DESCRIPTION
## Button Format

Edited factory.css so blocks no longer look disabled.
<img width="1440" alt="screen shot 2016-08-04 at 10 26 55 am" src="https://cloud.githubusercontent.com/assets/10423718/17411850/c7408bce-5a2e-11e6-99f9-73ce6c951468.png">
## Select Default Option on Creation of New Block

When user clicks 'Create New Block' update the dropdown such that no blocks in block library are selected.
- created selectDefaultOption function in BlockLibraryView
- called selectDefaultOption in AppController's click handler for 'Create New Block'
## Reorganized Block Library View
- rearranged the orders of the functions.
## Block Library Controller
- made getCurrentBlockType private

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quachtina96/blockly/22)

<!-- Reviewable:end -->
