### PR TITLE
Block Library: Import from/Export to XML file

### DIFF
--- a/demos/blockfactoryv2/block_exporter_controller.js
+++ b/demos/blockfactoryv2/block_exporter_controller.js
@@ -32,6 +32,28 @@ BlockExporterController = function(blockLibStorage) {
 };
 
 /**
+ * Set the block library storage object from which exporter exports.
+ *
+ * @param {!BlockLibraryStorage} blockLibStorage - Block Library Storage object
+ *    that stores the blocks.
+ */
+BlockExporterController.prototype.setBlockLibStorage =
+    function(blockLibStorage) {
+  this.blockLibStorage = blockLibStorage;
+};
+
+/**
+ * Get the block library storage object from which exporter exports.
+ *
+ * @return {!BlockLibraryStorage} blockLibStorage - Block Library Storage object
+ *    that stores the blocks.
+ */
+BlockExporterController.prototype.getBlockLibStorage =
+    function(blockLibStorage) {
+  return this.blockLibStorage;
+};
+
+/**
  * Get the selected block types.
  * @private
  *

--- a/demos/blockfactoryv2/block_library_controller.js
+++ b/demos/blockfactoryv2/block_library_controller.js
@@ -24,11 +24,13 @@ goog.require('BlockFactory');
  *
  * @param {string} blockLibraryName - Desired name of Block Library, also used
  *    to create the key for where it's stored in local storage.
+ * @param {!BlockLibraryStorage} opt_blockLibraryStorage - optional storage
+ *    object that allows user to import a block library.
  */
-BlockLibraryController = function(blockLibraryName) {
+BlockLibraryController = function(blockLibraryName, opt_blockLibraryStorage) {
   this.name = blockLibraryName;
   // Create a new, empty Block Library Storage object, or load existing one.
-  this.storage = new BlockLibraryStorage(this.name);
+  this.storage = opt_blockLibraryStorage || new BlockLibraryStorage(this.name);
 };
 
 /**
@@ -158,5 +160,36 @@ BlockLibraryController.prototype.populateBlockLibrary = function() {
           block, block, 'blockLibraryDropdown', false, true);
     }
   }
+};
+
+/**
+ * Return block library mapping block type to xml.
+ *
+ * @return {Object} Object mapping block type to xml text.
+ */
+BlockLibraryController.prototype.getBlockLibrary = function() {
+  return this.storage.getBlockXmlTextMap();
+};
+
+/**
+ * Set the block library storage object from which exporter exports.
+ *
+ * @param {!BlockLibraryStorage} blockLibStorage - Block Library Storage
+ *    object.
+ */
+BlockLibraryController.prototype.setBlockLibStorage
+    = function(blockLibStorage) {
+  this.storage = blockLibStorage;
+};
+
+/**
+ * Get the block library storage object from which exporter exports.
+ *
+ * @return {!BlockLibraryStorage} blockLibStorage - Block Library Storage object
+ *    that stores the blocks.
+ */
+BlockLibraryController.prototype.getBlockLibStorage =
+    function(blockLibStorage) {
+  return this.blockLibStorage;
 };
 

--- a/demos/blockfactoryv2/block_library_storage.js
+++ b/demos/blockfactoryv2/block_library_storage.js
@@ -15,17 +15,23 @@ goog.provide('BlockLibraryStorage');
  *
  * @param {string} blockLibraryName - Desired name of Block Library, also used
  *    to create the key for where it's stored in local storage.
+ * @param {Object} opt_blocks - Object mapping block type to xml.
  */
-BlockLibraryStorage = function(blockLibraryName) {
+BlockLibraryStorage = function(blockLibraryName, opt_blocks) {
   // Add prefix to this.name to avoid collisions in local storage.
   this.name = 'BlockLibraryStorage.' + blockLibraryName;
-  // Initialize this.blocks by loading from local storage.
-  this.loadFromLocalStorage();
-  if (this.blocks == null) {
-    this.blocks = Object.create(null);
-    // The line above is equivalent of {} except that this object is TRULY
-    // empty. It doesn't have built-in attributes/functions such as length or
-    // toString.
+  if (!opt_blocks) {
+    // Initialize this.blocks by loading from local storage.
+    this.loadFromLocalStorage();
+    if (this.blocks == null) {
+      this.blocks = Object.create(null);
+      // The line above is equivalent of {} except that this object is TRULY
+      // empty. It doesn't have built-in attributes/functions such as length or
+      // toString.
+      this.saveToLocalStorage();
+    }
+  } else {
+    this.blocks = opt_blocks;
     this.saveToLocalStorage();
   }
 };
@@ -34,7 +40,7 @@ BlockLibraryStorage = function(blockLibraryName) {
  * Reads the named block library from local storage and saves it in this.blocks.
  */
 BlockLibraryStorage.prototype.loadFromLocalStorage = function() {
-  // goog.global is synonymous to window, and  allows for flexibility
+  // goog.global is synonymous to window, and allows for flexibility
   // between browsers.
   var object = goog.global.localStorage[this.name];
   this.blocks = object ? JSON.parse(object) : null;
@@ -129,4 +135,13 @@ BlockLibraryStorage.prototype.isEmpty = function() {
     return false;
   }
   return true;
+};
+
+/**
+ * Returns array of all block types stored in current block library.
+ *
+ * @return {!Array.<string>} Map of block type to corresponding xml text.
+ */
+BlockLibraryStorage.prototype.getBlockXmlTextMap = function() {
+  return this.blocks;
 };

--- a/demos/blockfactoryv2/block_library_view.js
+++ b/demos/blockfactoryv2/block_library_view.js
@@ -95,4 +95,3 @@ BlockLibraryView.clearOptions = function(dropdownID) {
   }
 };
 
-

--- a/demos/blockfactoryv2/index.html
+++ b/demos/blockfactoryv2/index.html
@@ -23,10 +23,10 @@
   <link rel="stylesheet" href="../prettify.css">
   <script src="../prettify.js"></script>
   <script>
-    var blocklyDevTools;
+    var blocklyFactory;
     var init = function() {
-      blocklyDevTools = new AppController();
-      blocklyDevTools.init();
+      blocklyFactory = new AppController();
+      blocklyFactory.init();
     };
     window.addEventListener('load', init);
 </script>
@@ -131,12 +131,12 @@
                 <span> Create New Block</span>
               </button>
               <label for="files" class="buttonStyle">
-                <span class=>Import block</span>
+                <span class=>Import Block Library</span>
               </label>
               <input id="files" type="file" name="files"
                   accept="application/xml">
-              <button id="localSaveButton" title="Save block xml to a local file.">
-                <span>Download block</span>
+              <button id="localSaveButton" title="Save block library xml to a local file.">
+                <span>Download Block Library</span>
               </button>
               <button id="helpButton" title="View documentation in new window.">
                 <span>Help</span>


### PR DESCRIPTION
## Overview

Replaced the 'Import Block' and 'Export Block' buttons with 'Import Block Library' and 'Export Block Library'. User uploads XML files that are parsed and stored into the block library. When they are done or are happy with their block library, they can export their block library as each block's xml separated by a new line.

<img width="1436" alt="screen shot 2016-08-05 at 11 06 42 am" src="https://cloud.githubusercontent.com/assets/10423718/17446276/54d70c1e-5afd-11e6-99c7-4ffbf38997da.png">
<img width="996" alt="screen shot 2016-08-05 at 11 06 55 am" src="https://cloud.githubusercontent.com/assets/10423718/17446278/56558f8e-5afd-11e6-9c38-2f66a86a4b9b.png">

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quachtina96/blockly/25)

<!-- Reviewable:end -->
